### PR TITLE
Add hack to enable RGB control for devices without light_saturation

### DIFF
--- a/lib/homekit.js
+++ b/lib/homekit.js
@@ -111,7 +111,7 @@ function createLight(device, id) {
     capabilities.push(hue);
 
     // Hack to enable RGB control in Homekit for devices with only light_hue capability
-    if (!('light_saturation') in device.capabilities) {
+    if (!('light_saturation' in device.capabilities)) {
         // If device has sat capability
         console.log('Found light_saturation!', 'info', device.capabilities);
         // Switch the capability on user input

--- a/lib/homekit.js
+++ b/lib/homekit.js
@@ -109,6 +109,19 @@ function createLight(device, id) {
     });
     // Push to array
     capabilities.push(hue);
+
+    // Hack to enable RGB control in Homekit for devices with only light_hue capability
+    if (!('light_saturation') in device.capabilities) {
+        // If device has sat capability
+        console.log('Found light_saturation!', 'info', device.capabilities);
+        // Switch the capability on user input
+        var sat = HAS.predefined.Saturation(11, device.state.light_saturation * 100 || 100, (value, callback) => {
+            callback(HAS.statusCodes.OK);
+        });
+
+        // Push to array
+        capabilities.push(sat);
+    }
   }
 
   // If device has sat capability


### PR DESCRIPTION
There are some devices that allow RGB control whilst not having the light_saturation capability (Milight stuff for example). This PR cheats a bit by letting HomeKit think the device can do light_saturation while it can't. This is necessary as without the light_saturation capability HomeKit does not display the controls for changing RGB (as it needs the saturation capability in the same component).

PS. this is a personal PR nothing to do with Athom. I am using HomeyKit myself and lacked the ability to control the RGB of my Milight LED strips. 