### PR TITLE
Replace Saturation with ColorTemperature for light_temperature control

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const debug = true;
+const debug = false;
 
 // Enable TCP debug
 // process.env.DEBUG = 'TCP';

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const debug = false;
+const debug = true;
 
 // Enable TCP debug
 // process.env.DEBUG = 'TCP';

--- a/lib/homekit.js
+++ b/lib/homekit.js
@@ -95,10 +95,16 @@ function createLight(device, id) {
   if ('light_hue' in device.capabilities) {
     console.log('Found light_hue!', 'info');
     // Switch the capability on user input
-    var hue = HAS.predefined.Hue(10, device.state.light_hue * 360 || 360, (value, callback) => {
+    var hue = HAS.predefined.Hue(10, device.state.light_hue * 360 || 360, async (value, callback) => {
       // Calling the api
       // console.log("Hue: " + value / 360)
       console.log('Switching light_hue for: ' + device.name + '. Value: ' +  value/360, "info");
+
+      // If device uses light_mode and was previously set on not color
+      // wait for color mode to be adjusted before setting hue
+	  if ('light_mode' in device.capabilities && device.state.light_mode !== 'color') {
+	    await device.setCapabilityValue("light_mode", "color");
+	  }
       device.setCapabilityValue("light_hue", value / 360)
       callback(HAS.statusCodes.OK);
     });
@@ -115,17 +121,23 @@ function createLight(device, id) {
   if ('light_saturation' in device.capabilities) {
     console.log('Found light_saturation!', 'info');
     // Switch the capability on user input
-    var sat = HAS.predefined.Saturation(11, device.state.light_saturation * 100 || 100, (value, callback) => {
+    var sat = HAS.predefined.Saturation(11, device.state.light_saturation * 100 || 100, async (value, callback) => {
       // Calling the api
       // console.log("Saturation: " + value / 100)
       console.log('Switching light_saturation for: ' + device.name + '. Value: ' +  value/100, "info");
-      device.setCapabilityValue("light_saturation", value / 100)
+
+      // If device uses light_mode and was previously set on not color
+	  // wait for color mode to be adjusted before setting hue
+      if ('light_mode' in device.capabilities && device.state.light_mode !== 'color') {
+	    await device.setCapabilityValue("light_mode", "color");
+	  }
+	  device.setCapabilityValue("light_saturation", value / 100)
       callback(HAS.statusCodes.OK);
     });
 
     // Check for realtime events
     device.on('$state', state => {
-      sat.setValue(state.light_saturation * 100 || 100);
+        sat.setValue(state.light_saturation * 100 || 100);
     });
     // Push to array
     capabilities.push(sat);
@@ -139,17 +151,27 @@ function createLight(device, id) {
     console.log('Found light_temp!', 'info');
     // Switch the capability on user input
       // Not sure about first param '12', but seems to work
-    var temp = HAS.predefined.ColorTemperature(12, map(0, 1, 140, 500, device.state.light_temperature || 1) || 500, (value, callback) => {
+    var temp = HAS.predefined.ColorTemperature(12, map(0, 1, 140, 500, device.state.light_temperature || 1) || 500, async (value, callback) => {
       // Calling the api
       // console.log("Saturation: " + value / 100)
       console.log('Switching light_temperature for: ' + device.name + '. Value: ' +   map(140, 500, 0, 1, value), "info");
+
+	  // If device uses light_mode and was previously set on not temperature
+	  // wait for color mode to be adjusted before setting light_temperature
+      if ('light_mode' in device.capabilities && device.state.light_mode !== 'temperature') {
+	    await device.setCapabilityValue("light_mode", "temperature");
+	  }
       device.setCapabilityValue("light_temperature", map(140, 500, 0, 1, value));
       callback(HAS.statusCodes.OK);
     });
 
     // Check for realtime events
     device.on('$state', state => {
-      temp.setValue(map(0, 1, 140, 500, device.state.light_temperature) || 400);
+      if (device.state.light_mode === 'temperature') {
+	    sat.setValue(0);
+	    hue.setValue(0);
+	    temp.setValue(map(0, 1, 140, 500, device.state.light_temperature) || 500);
+      }
     });
     // Push to array
     capabilities.push(temp);

--- a/lib/homekit.js
+++ b/lib/homekit.js
@@ -135,20 +135,21 @@ function createLight(device, id) {
     return outputStart + ((outputEnd - outputStart) / (inputEnd - inputStart)) * (input - inputStart);
   }
 
-  if (!'light_saturation' in device.capabilities && !'light_hue' in device.capabilities && 'light_temperature' in device.capabilities) {
+  if ('light_temperature' in device.capabilities) {
     console.log('Found light_temp!', 'info');
     // Switch the capability on user input
-    var temp = HAS.predefined.Saturation(12, map(0, 1, 50, 400, device.state.light_temperature) || 400, (value, callback) => {
+      // Not sure about first param '12', but seems to work
+    var temp = HAS.predefined.ColorTemperature(12, map(0, 1, 140, 500, device.state.light_temperature || 1) || 500, (value, callback) => {
       // Calling the api
       // console.log("Saturation: " + value / 100)
-      console.log('Switching light_temperature for: ' + device.name + '. Value: ' +   map(50, 400, 0, 1, value), "info");
-      device.setCapabilityValue("light_temperature", map(50, 400, 0, 1, value))
+      console.log('Switching light_temperature for: ' + device.name + '. Value: ' +   map(140, 500, 0, 1, value), "info");
+      device.setCapabilityValue("light_temperature", map(140, 500, 0, 1, value));
       callback(HAS.statusCodes.OK);
     });
 
     // Check for realtime events
     device.on('$state', state => {
-      temp.setValue(map(0, 1, 50, 400, device.state.light_temperature) || 400);
+      temp.setValue(map(0, 1, 140, 500, device.state.light_temperature) || 400);
     });
     // Push to array
     capabilities.push(temp);

--- a/lib/homekit.js
+++ b/lib/homekit.js
@@ -115,6 +115,25 @@ function createLight(device, id) {
     });
     // Push to array
     capabilities.push(hue);
+
+    // Hack to enable RGB control in Homekit for devices with only light_hue capability
+    if (!('light_saturation' in device.capabilities)) {
+        // If device has sat capability
+        console.log('Found light_saturation!', 'info', device.capabilities);
+        // Switch the capability on user input
+        var sat = HAS.predefined.Saturation(11, device.state.light_saturation * 100 || 100, async (value, callback) => {
+
+            // If device uses light_mode and was previously set on not color
+            // wait for color mode to be adjusted before setting hue
+            if ('light_mode' in device.capabilities && device.state.light_mode !== 'color') {
+                await device.setCapabilityValue("light_mode", "color");
+            }
+            callback(HAS.statusCodes.OK);
+        });
+
+        // Push to array
+        capabilities.push(sat);
+    }
   }
 
   // If device has sat capability

--- a/node_modules/has-node/src/predefinedTypes/data.json
+++ b/node_modules/has-node/src/predefinedTypes/data.json
@@ -95,93 +95,96 @@
   ],
   "Characteristics" : [
     {
+      "UUID" : "000000A6-0000-1000-8000-0026BB765291",
+      "Name" : "Accessory Flags",
+      "Format" : "uint32",
       "Constraints" : {
-        "ValidValues" : {
-          "0" : "Additional Setup Required"
+        "ValidBits" : {
+          "0" : "Requires Additional Setup"
         }
       },
-      "Name" : "Accessory Flags",
-      "UUID" : "000000A6-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint32",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "000000B0-0000-1000-8000-0026BB765291",
+      "Name" : "Active",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Inactive",
           "1" : "Active"
         }
       },
-      "Name" : "Active",
-      "UUID" : "000000B0-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
       "Name" : "Administrator Only Access",
-      "UUID" : "00000001-0000-1000-8000-0026BB765291",
+      "Format" : "bool",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
       ],
-      "Format" : "bool",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
-      ]
+      "UUID" : "00000001-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "00000064-0000-1000-8000-0026BB765291",
+      "Name" : "Air Particulate Density",
+      "Format" : "float",
       "Constraints" : {
         "StepValue" : 1,
         "MaximumValue" : 1000,
         "MinimumValue" : 0
       },
-      "Name" : "Air Particulate Density",
-      "UUID" : "00000064-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "00000065-0000-1000-8000-0026BB765291",
+      "Name" : "Air Particulate Size",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "2.5 μm",
           "1" : "10 μm"
         }
       },
-      "Name" : "Air Particulate Size",
-      "UUID" : "00000065-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "00000095-0000-1000-8000-0026BB765291",
+      "Name" : "Air Quality",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "3" : "Fair",
@@ -192,42 +195,28 @@
           "5" : "Poor"
         }
       },
-      "Name" : "Air Quality",
-      "UUID" : "00000095-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
-      ]
-    },
-    {
-      "Name" : "App Matching Identifier",
-      "UUID" : "000000A4-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
-      ],
-      "Format" : "tlv8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
       "Name" : "Audio Feedback",
-      "UUID" : "00000005-0000-1000-8000-0026BB765291",
+      "Format" : "bool",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
       ],
-      "Format" : "bool",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
-      ]
+      "UUID" : "00000005-0000-1000-8000-0026BB765291"
     },
     {
       "Format" : "uint8",
@@ -268,112 +257,111 @@
       }
     },
     {
+      "UUID" : "00000092-0000-1000-8000-0026BB765291",
+      "Name" : "Carbon Dioxide Detected",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "CO2 Levels Normal",
           "1" : "CO2 Levels Abnormal"
         }
       },
-      "Name" : "Carbon Dioxide Detected",
-      "UUID" : "00000092-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
-      "Constraints" : {
-        "StepValue" : 100,
-        "MaximumValue" : 100000,
-        "MinimumValue" : 0
-      },
-      "Name" : "Carbon Dioxide Level",
       "UUID" : "00000093-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "cnotify"
-      ],
+      "Name" : "Carbon Dioxide Level",
       "Format" : "float",
-      "Permissions" : [
-        "securedRead"
-      ]
-    },
-    {
       "Constraints" : {
-        "StepValue" : 100,
         "MaximumValue" : 100000,
         "MinimumValue" : 0
       },
-      "Name" : "Carbon Dioxide Peak Level",
-      "UUID" : "00000094-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "00000094-0000-1000-8000-0026BB765291",
+      "Name" : "Carbon Dioxide Peak Level",
+      "Format" : "float",
+      "Constraints" : {
+        "MaximumValue" : 100000,
+        "MinimumValue" : 0
+      },
+      "Permissions" : [
+        "securedRead"
+      ],
+      "Properties" : [
+        "read",
+        "cnotify"
+      ]
+    },
+    {
+      "UUID" : "00000069-0000-1000-8000-0026BB765291",
+      "Name" : "Carbon Monoxide Detected",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "CO Levels Normal",
           "1" : "CO Levels Abnormal"
         }
       },
-      "Name" : "Carbon Monoxide Detected",
-      "UUID" : "00000069-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
-      "Constraints" : {
-        "StepValue" : 0.1,
-        "MaximumValue" : 100,
-        "MinimumValue" : 0
-      },
-      "Name" : "Carbon Monoxide Level",
       "UUID" : "00000090-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "cnotify"
-      ],
+      "Name" : "Carbon Monoxide Level",
       "Format" : "float",
-      "Permissions" : [
-        "securedRead"
-      ]
-    },
-    {
       "Constraints" : {
-        "StepValue" : 0.1,
         "MaximumValue" : 100,
         "MinimumValue" : 0
       },
-      "Name" : "Carbon Monoxide Peak Level",
-      "UUID" : "00000091-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "00000091-0000-1000-8000-0026BB765291",
+      "Name" : "Carbon Monoxide Peak Level",
+      "Format" : "float",
+      "Constraints" : {
+        "MaximumValue" : 100,
+        "MinimumValue" : 0
+      },
+      "Permissions" : [
+        "securedRead"
+      ],
+      "Properties" : [
+        "read",
+        "cnotify"
+      ]
+    },
+    {
+      "UUID" : "0000008F-0000-1000-8000-0026BB765291",
+      "Name" : "Charging State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Not Charging",
@@ -381,34 +369,50 @@
           "2" : "Not Chargeable"
         }
       },
-      "Name" : "Charging State",
-      "UUID" : "0000008F-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "000000CE-0000-1000-8000-0026BB765291",
+      "Name" : "Color Temperature",
+      "Format" : "uint32",
+      "Constraints" : {
+        "StepValue" : 1,
+        "MaximumValue" : 500,
+        "MinimumValue" : 140
+      },
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
+      "Properties" : [
+        "read",
+        "write",
+        "cnotify"
+      ]
+    },
+    {
+      "UUID" : "0000006A-0000-1000-8000-0026BB765291",
+      "Name" : "Contact Sensor State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Contact Detected",
           "1" : "Contact Not Detected"
         }
       },
-      "Name" : "Contact Sensor State",
-      "UUID" : "0000006A-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
@@ -432,6 +436,9 @@
       }
     },
     {
+      "UUID" : "000000A9-0000-1000-8000-0026BB765291",
+      "Name" : "Current Air Purifier State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Inactive",
@@ -439,15 +446,12 @@
           "2" : "Purifying Air"
         }
       },
-      "Name" : "Current Air Purifier State",
-      "UUID" : "000000A9-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
@@ -463,12 +467,14 @@
       ],
       "Unit" : "lux",
       "Constraints" : {
-        "StepValue" : 0.0001,
         "MaximumValue" : 100000,
         "MinimumValue" : 0.0001
       }
     },
     {
+      "UUID" : "0000000E-0000-1000-8000-0026BB765291",
+      "Name" : "Current Door State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "3" : "Closing",
@@ -478,19 +484,19 @@
           "0" : "Open"
         }
       },
-      "Name" : "Current Door State",
-      "UUID" : "0000000E-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "000000AF-0000-1000-8000-0026BB765291",
+      "Name" : "Current Fan State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Inactive",
@@ -498,18 +504,18 @@
           "2" : "Blowing Air"
         }
       },
-      "Name" : "Current Fan State",
-      "UUID" : "000000AF-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "000000B1-0000-1000-8000-0026BB765291",
+      "Name" : "Current Heater Cooler State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "3" : "Cooling",
@@ -518,18 +524,18 @@
           "0" : "Inactive"
         }
       },
-      "Name" : "Current Heater Cooler State",
-      "UUID" : "000000B1-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "0000000F-0000-1000-8000-0026BB765291",
+      "Name" : "Current Heating Cooling State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Off",
@@ -537,16 +543,13 @@
           "2" : "Cool"
         }
       },
-      "Name" : "Current Heating Cooling State",
-      "UUID" : "0000000F-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
@@ -568,6 +571,9 @@
       }
     },
     {
+      "UUID" : "000000B3-0000-1000-8000-0026BB765291",
+      "Name" : "Current Humidifier Dehumidifier State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "3" : "Dehumidifying",
@@ -576,15 +582,12 @@
           "0" : "Inactive"
         }
       },
-      "Name" : "Current Humidifier Dehumidifier State",
-      "UUID" : "000000B3-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
@@ -624,6 +627,9 @@
       }
     },
     {
+      "UUID" : "000000AA-0000-1000-8000-0026BB765291",
+      "Name" : "Current Slat State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Fixed",
@@ -631,15 +637,12 @@
           "2" : "Swinging"
         }
       },
-      "Name" : "Current Slat State",
-      "UUID" : "000000AA-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
@@ -698,73 +701,74 @@
     },
     {
       "Name" : "Digital Zoom",
-      "UUID" : "0000011D-0000-1000-8000-0026BB765291",
+      "Format" : "float",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
       ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
-      ]
+      "UUID" : "0000011D-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "000000AC-0000-1000-8000-0026BB765291",
+      "Name" : "Filter Change Indication",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Filter OK",
           "1" : "Change Filter"
         }
       },
-      "Name" : "Filter Change Indication",
-      "UUID" : "000000AC-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "000000AB-0000-1000-8000-0026BB765291",
+      "Name" : "Filter Life Level",
+      "Format" : "float",
       "Constraints" : {
+        "stepValue" : 1,
         "MaximumValue" : 100,
         "MinimumValue" : 0
       },
-      "Name" : "Filter Life Level",
-      "UUID" : "000000AB-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
       "Name" : "Firmware Revision",
-      "UUID" : "00000052-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
-      ],
       "Format" : "string",
       "Permissions" : [
         "securedRead"
-      ]
+      ],
+      "Properties" : [
+        "read"
+      ],
+      "UUID" : "00000052-0000-1000-8000-0026BB765291"
     },
     {
       "Name" : "Hardware Revision",
-      "UUID" : "00000053-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
-      ],
       "Format" : "string",
       "Permissions" : [
         "securedRead"
-      ]
+      ],
+      "Properties" : [
+        "read"
+      ],
+      "UUID" : "00000053-0000-1000-8000-0026BB765291"
     },
     {
       "Format" : "float",
@@ -788,14 +792,14 @@
     },
     {
       "Name" : "Hold Position",
-      "UUID" : "0000006F-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "write"
-      ],
       "Format" : "bool",
       "Permissions" : [
         "securedWrite"
-      ]
+      ],
+      "Properties" : [
+        "write"
+      ],
+      "UUID" : "0000006F-0000-1000-8000-0026BB765291"
     },
     {
       "Format" : "float",
@@ -819,28 +823,28 @@
     },
     {
       "Name" : "Identify",
-      "UUID" : "00000014-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "write"
-      ],
       "Format" : "bool",
       "Permissions" : [
         "securedWrite"
-      ]
+      ],
+      "Properties" : [
+        "write"
+      ],
+      "UUID" : "00000014-0000-1000-8000-0026BB765291"
     },
     {
       "Name" : "Image Mirroring",
-      "UUID" : "0000011F-0000-1000-8000-0026BB765291",
+      "Format" : "bool",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
       ],
-      "Format" : "bool",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
-      ]
+      "UUID" : "0000011F-0000-1000-8000-0026BB765291"
     },
     {
       "Format" : "float",
@@ -863,36 +867,39 @@
       }
     },
     {
+      "UUID" : "00000070-0000-1000-8000-0026BB765291",
+      "Name" : "Leak Detected",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Leak Not Detected",
           "1" : "Leak Detected"
         }
       },
-      "Name" : "Leak Detected",
-      "UUID" : "00000070-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
       "Name" : "Lock Control Point",
-      "UUID" : "00000019-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "write"
-      ],
       "Format" : "tlv8",
       "Permissions" : [
         "securedWrite"
-      ]
+      ],
+      "Properties" : [
+        "write"
+      ],
+      "UUID" : "00000019-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "0000001D-0000-1000-8000-0026BB765291",
+      "Name" : "Lock Current State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "3" : "Unknown",
@@ -901,19 +908,19 @@
           "0" : "Unsecured"
         }
       },
-      "Name" : "Lock Current State",
-      "UUID" : "0000001D-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "0000001C-0000-1000-8000-0026BB765291",
+      "Name" : "Lock Last Known Action",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "7" : "Unsecured Remotely",
@@ -927,359 +934,354 @@
           "2" : "Secured Physically, Exterior"
         }
       },
-      "Name" : "Lock Last Known Action",
-      "UUID" : "0000001C-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "Unit" : "seconds",
+      "Name" : "Lock Management Auto Security Timeout",
       "Format" : "uint32",
-      "UUID" : "0000001A-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
       ],
-      "Name" : "Lock Management Auto Security Timeout",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
-      ],
-      "Unit" : "seconds",
-      "Constraints" : {
-        "StepValue" : 1,
-        "MaximumValue" : 86400,
-        "MinimumValue" : 0
-      }
+      "UUID" : "0000001A-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "000000A7-0000-1000-8000-0026BB765291",
+      "Name" : "Lock Physical Controls",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Control Lock Disabled",
           "1" : "Control Lock Enabled"
         }
       },
-      "Name" : "Lock Physical Controls",
-      "UUID" : "000000A7-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
+      "UUID" : "0000001E-0000-1000-8000-0026BB765291",
+      "Name" : "Lock Target State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Unsecured",
           "1" : "Secured"
         }
       },
-      "Name" : "Lock Target State",
-      "UUID" : "0000001E-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
       "Name" : "Logs",
-      "UUID" : "0000001F-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "cnotify"
-      ],
       "Format" : "tlv8",
       "Permissions" : [
         "securedRead"
-      ]
+      ],
+      "Properties" : [
+        "read",
+        "cnotify"
+      ],
+      "UUID" : "0000001F-0000-1000-8000-0026BB765291"
     },
     {
       "Name" : "Manufacturer",
-      "UUID" : "00000020-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
-      ],
       "Format" : "string",
       "Permissions" : [
         "securedRead"
-      ]
+      ],
+      "Properties" : [
+        "read"
+      ],
+      "UUID" : "00000020-0000-1000-8000-0026BB765291"
     },
     {
       "Name" : "Model",
-      "UUID" : "00000021-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
-      ],
       "Format" : "string",
       "Permissions" : [
         "securedRead"
-      ]
-    },
-    {
-      "Name" : "Mute",
-      "UUID" : "0000011A-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "write",
-        "cnotify"
       ],
-      "Format" : "bool",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
-      ]
+      "Properties" : [
+        "read"
+      ],
+      "UUID" : "00000021-0000-1000-8000-0026BB765291"
     },
     {
       "Name" : "Motion Detected",
-      "UUID" : "00000022-0000-1000-8000-0026BB765291",
+      "Format" : "bool",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
       ],
+      "UUID" : "00000022-0000-1000-8000-0026BB765291"
+    },
+    {
+      "Name" : "Mute",
       "Format" : "bool",
       "Permissions" : [
-        "securedRead"
-      ]
-    },
-    {
-      "Name" : "Name",
-      "UUID" : "00000023-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
+        "securedRead",
+        "securedWrite"
       ],
-      "Format" : "string",
-      "Permissions" : [
-        "securedRead"
-      ]
-    },
-    {
-      "Name" : "Night Vision",
-      "UUID" : "0000011B-0000-1000-8000-0026BB765291",
       "Properties" : [
         "read",
         "write",
         "cnotify"
       ],
+      "UUID" : "0000011A-0000-1000-8000-0026BB765291"
+    },
+    {
+      "Name" : "Name",
+      "Format" : "string",
+      "Permissions" : [
+        "securedRead"
+      ],
+      "Properties" : [
+        "read"
+      ],
+      "UUID" : "00000023-0000-1000-8000-0026BB765291"
+    },
+    {
+      "Name" : "Night Vision",
       "Format" : "bool",
       "Permissions" : [
         "securedRead",
         "securedWrite"
-      ]
+      ],
+      "Properties" : [
+        "read",
+        "write",
+        "cnotify"
+      ],
+      "UUID" : "0000011B-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "000000C4-0000-1000-8000-0026BB765291",
+      "Name" : "Nitrogen Dioxide Density",
+      "Format" : "float",
       "Constraints" : {
         "StepValue" : 1,
         "MaximumValue" : 1000,
         "MinimumValue" : 0
       },
-      "Name" : "Nitrogen Dioxide Density",
-      "UUID" : "000000C4-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
       "Name" : "Obstruction Detected",
-      "UUID" : "00000024-0000-1000-8000-0026BB765291",
+      "Format" : "bool",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
       ],
-      "Format" : "bool",
-      "Permissions" : [
-        "securedRead"
-      ]
+      "UUID" : "00000024-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "00000071-0000-1000-8000-0026BB765291",
+      "Name" : "Occupancy Detected",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Occupancy Not Detected",
           "1" : "Occupancy Detected"
         }
       },
-      "Name" : "Occupancy Detected",
-      "UUID" : "00000071-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
       "Name" : "On",
-      "UUID" : "00000025-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "write",
-        "cnotify"
-      ],
       "Format" : "bool",
       "Permissions" : [
         "securedRead",
         "securedWrite"
-      ]
-    },
-    {
-      "Name" : "Optical Zoom",
-      "UUID" : "0000011C-0000-1000-8000-0026BB765291",
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
       ],
+      "UUID" : "00000025-0000-1000-8000-0026BB765291"
+    },
+    {
+      "Name" : "Optical Zoom",
       "Format" : "float",
       "Permissions" : [
         "securedRead",
         "securedWrite"
-      ]
+      ],
+      "Properties" : [
+        "read",
+        "write",
+        "cnotify"
+      ],
+      "UUID" : "0000011C-0000-1000-8000-0026BB765291"
     },
     {
       "Name" : "Outlet In Use",
-      "UUID" : "00000026-0000-1000-8000-0026BB765291",
+      "Format" : "bool",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
       ],
-      "Format" : "bool",
-      "Permissions" : [
-        "securedRead"
-      ]
+      "UUID" : "00000026-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "000000C3-0000-1000-8000-0026BB765291",
+      "Name" : "Ozone Density",
+      "Format" : "float",
       "Constraints" : {
         "StepValue" : 1,
         "MaximumValue" : 1000,
         "MinimumValue" : 0
       },
-      "Name" : "Ozone Density",
-      "UUID" : "000000C3-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
       "Name" : "Pair Setup",
-      "UUID" : "0000004C-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "write"
-      ],
       "Format" : "tlv8",
       "Permissions" : [
         "read",
         "write"
-      ]
+      ],
+      "Properties" : [
+        "read",
+        "write"
+      ],
+      "UUID" : "0000004C-0000-1000-8000-0026BB765291"
     },
     {
       "Name" : "Pair Verify",
-      "UUID" : "0000004E-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "write"
-      ],
       "Format" : "tlv8",
       "Permissions" : [
         "read",
         "write"
-      ]
-    },
-    {
-      "Name" : "Pairing Features",
-      "UUID" : "0000004F-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
       ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "read"
-      ]
-    },
-    {
-      "Name" : "Pairing Pairings",
-      "UUID" : "00000050-0000-1000-8000-0026BB765291",
       "Properties" : [
         "read",
         "write"
       ],
+      "UUID" : "0000004E-0000-1000-8000-0026BB765291"
+    },
+    {
+      "Name" : "Pairing Features",
+      "Format" : "uint8",
+      "Permissions" : [
+        "read"
+      ],
+      "Properties" : [
+        "read"
+      ],
+      "UUID" : "0000004F-0000-1000-8000-0026BB765291"
+    },
+    {
+      "Name" : "Pairing Pairings",
       "Format" : "tlv8",
       "Permissions" : [
         "securedRead",
         "securedWrite"
-      ]
+      ],
+      "Properties" : [
+        "read",
+        "write"
+      ],
+      "UUID" : "00000050-0000-1000-8000-0026BB765291"
     },
     {
-      "Constraints" : {
-        "StepValue" : 1,
-        "MaximumValue" : 1000,
-        "MinimumValue" : 0
-      },
-      "Name" : "PM10 Density",
       "UUID" : "000000C7-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "cnotify",
-        "uncnotify"
-      ],
+      "Name" : "PM10 Density",
       "Format" : "float",
-      "Permissions" : [
-        "securedRead"
-      ]
-    },
-    {
       "Constraints" : {
         "StepValue" : 1,
         "MaximumValue" : 1000,
         "MinimumValue" : 0
       },
-      "Name" : "PM2.5 Density",
-      "UUID" : "000000C6-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "000000C6-0000-1000-8000-0026BB765291",
+      "Name" : "PM2.5 Density",
+      "Format" : "float",
+      "Constraints" : {
+        "StepValue" : 1,
+        "MaximumValue" : 1000,
+        "MinimumValue" : 0
+      },
+      "Permissions" : [
+        "securedRead"
+      ],
+      "Properties" : [
+        "read",
+        "cnotify",
+        "uncnotify"
+      ]
+    },
+    {
+      "UUID" : "00000072-0000-1000-8000-0026BB765291",
+      "Name" : "Position State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Decreasing",
@@ -1287,125 +1289,105 @@
           "2" : "Stopped"
         }
       },
-      "Name" : "Position State",
-      "UUID" : "00000072-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
-      "Constraints" : {
-        "StepValue" : 1,
-        "MaximumValue" : 1,
-        "MinimumValue" : 0
-      },
-      "Name" : "Programmable Switch Event",
       "UUID" : "00000073-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "cnotify"
-      ],
+      "Name" : "Programmable Switch Event",
       "Format" : "uint8",
+      "Constraints" : {
+        "ValidValues" : {
+          "0" : "Single Press",
+          "1" : "Double Press",
+          "2" : "Long Press"
+        }
+      },
       "Permissions" : [
         "securedRead"
-      ]
-    },
-    {
-      "Constraints" : {
-        "StepValue" : 1,
-        "MaximumValue" : 1,
-        "MinimumValue" : 0
-      },
-      "Name" : "Programmable Switch Output State",
-      "UUID" : "00000074-0000-1000-8000-0026BB765291",
+      ],
       "Properties" : [
         "read",
-        "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
-      "Constraints" : {
-        "StepValue" : 1,
-        "MaximumValue" : 100,
-        "MinimumValue" : 0
-      },
-      "Name" : "Relative Humidity Dehumidifier Threshold",
       "UUID" : "000000C9-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "write",
-        "cnotify"
-      ],
+      "Name" : "Relative Humidity Dehumidifier Threshold",
       "Format" : "float",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
-      ]
-    },
-    {
       "Constraints" : {
         "StepValue" : 1,
         "MaximumValue" : 100,
         "MinimumValue" : 0
       },
-      "Name" : "Relative Humidity Humidifier Threshold",
-      "UUID" : "000000CA-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
+      "UUID" : "000000CA-0000-1000-8000-0026BB765291",
+      "Name" : "Relative Humidity Humidifier Threshold",
+      "Format" : "float",
+      "Constraints" : {
+        "StepValue" : 1,
+        "MaximumValue" : 100,
+        "MinimumValue" : 0
+      },
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
+      "Properties" : [
+        "read",
+        "write",
+        "cnotify"
+      ]
+    },
+    {
+      "UUID" : "000000AD-0000-1000-8000-0026BB765291",
+      "Name" : "Reset Filter Indication",
+      "Format" : "uint8",
       "Constraints" : {
         "StepValue" : 1,
         "MaximumValue" : 1,
         "MinimumValue" : 1
       },
-      "Name" : "Reset Filter Indication",
-      "UUID" : "000000AD-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "write"
-      ],
-      "Format" : "uint8",
       "Permissions" : [
         "securedWrite"
+      ],
+      "Properties" : [
+        "write"
       ]
     },
     {
+      "UUID" : "00000028-0000-1000-8000-0026BB765291",
+      "Name" : "Rotation Direction",
+      "Format" : "int32",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Clockwise",
           "1" : "Counter-clockwise"
         }
       },
-      "Name" : "Rotation Direction",
-      "UUID" : "00000028-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "int32",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
@@ -1449,23 +1431,26 @@
       }
     },
     {
+      "UUID" : "0000008E-0000-1000-8000-0026BB765291",
+      "Name" : "Security System Alarm Type",
+      "Format" : "uint8",
       "Constraints" : {
         "StepValue" : 1,
         "MaximumValue" : 1,
         "MinimumValue" : 0
       },
-      "Name" : "Security System Alarm Type",
-      "UUID" : "0000008E-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "00000066-0000-1000-8000-0026BB765291",
+      "Name" : "Security System Current State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "3" : "Disarmed",
@@ -1475,19 +1460,19 @@
           "0" : "Stay Arm"
         }
       },
-      "Name" : "Security System Current State",
-      "UUID" : "00000066-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "00000067-0000-1000-8000-0026BB765291",
+      "Name" : "Security System Target State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "3" : "Disarm",
@@ -1496,299 +1481,320 @@
           "0" : "Stay Arm"
         }
       },
-      "Name" : "Security System Target State",
-      "UUID" : "00000067-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
-      "Name" : "Selected Stream Configuration",
-      "UUID" : "00000117-0000-1000-8000-0026BB765291",
+      "Name" : "Selected RTP Stream Configuration",
+      "Format" : "tlv8",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write"
       ],
-      "Format" : "tlv8",
+      "UUID" : "00000117-0000-1000-8000-0026BB765291"
+    },
+    {
+      "UUID" : "00000030-0000-1000-8000-0026BB765291",
+      "Name" : "Serial Number",
+      "Format" : "string",
+      "Constraints" : {
+        "MaximumLength" : 64
+      },
       "Permissions" : [
-        "securedRead",
-        "securedWrite"
+        "securedRead"
+      ],
+      "Properties" : [
+        "read"
       ]
     },
     {
-      "Name" : "Serial Number",
-      "UUID" : "00000030-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
-      ],
-      "Format" : "string",
+      "UUID" : "000000CB-0000-1000-8000-0026BB765291",
+      "Name" : "Service Label Index",
+      "Format" : "uint8",
+      "Constraints" : {
+        "StepValue" : 1,
+        "MaximumValue" : 255,
+        "MinimumValue" : 1
+      },
       "Permissions" : [
         "securedRead"
+      ],
+      "Properties" : [
+        "read"
+      ]
+    },
+    {
+      "UUID" : "000000CD-0000-1000-8000-0026BB765291",
+      "Name" : "Service Label Namespace",
+      "Format" : "uint8",
+      "Constraints" : {
+        "ValidValues" : {
+          "0" : "Dots",
+          "1" : "Arabic Numerals"
+        }
+      },
+      "Permissions" : [
+        "securedRead"
+      ],
+      "Properties" : [
+        "read"
       ]
     },
     {
       "Name" : "Setup Endpoints",
-      "UUID" : "00000118-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "write",
-        "cnotify"
-      ],
       "Format" : "tlv8",
       "Permissions" : [
         "securedRead",
         "securedWrite"
-      ]
+      ],
+      "Properties" : [
+        "read",
+        "write"
+      ],
+      "UUID" : "00000118-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "000000C0-0000-1000-8000-0026BB765291",
+      "Name" : "Slat Type",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Horizontal",
           "1" : "Vertical"
         }
       },
-      "Name" : "Slat Type",
-      "UUID" : "000000C0-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "cnotify"
-      ],
-      "Format" : "uint8",
       "Permissions" : [
         "securedRead"
+      ],
+      "Properties" : [
+        "read"
       ]
     },
     {
+      "UUID" : "00000076-0000-1000-8000-0026BB765291",
+      "Name" : "Smoke Detected",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Smoke Not Detected",
           "1" : "Smoke Detected"
         }
       },
-      "Name" : "Smoke Detected",
-      "UUID" : "00000076-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
-      ]
-    },
-    {
-      "Name" : "Software Revision",
-      "UUID" : "00000054-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
-      ],
-      "Format" : "string",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
       "Name" : "Status Active",
-      "UUID" : "00000075-0000-1000-8000-0026BB765291",
+      "Format" : "bool",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
       ],
-      "Format" : "bool",
-      "Permissions" : [
-        "securedRead"
-      ]
+      "UUID" : "00000075-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "00000077-0000-1000-8000-0026BB765291",
+      "Name" : "Status Fault",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "No Fault",
           "1" : "General Fault"
         }
       },
-      "Name" : "Status Fault",
-      "UUID" : "00000077-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "00000078-0000-1000-8000-0026BB765291",
+      "Name" : "Status Jammed",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Not Jammed",
           "1" : "Jammed"
         }
       },
-      "Name" : "Status Jammed",
-      "UUID" : "00000078-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "00000079-0000-1000-8000-0026BB765291",
+      "Name" : "Status Low Battery",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Battery Level Normal",
           "1" : "Battery Level Low"
         }
       },
-      "Name" : "Status Low Battery",
-      "UUID" : "00000079-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "0000007A-0000-1000-8000-0026BB765291",
+      "Name" : "Status Tampered",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Not Tampered",
           "1" : "Tampered"
         }
       },
-      "Name" : "Status Tampered",
-      "UUID" : "0000007A-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
       "Name" : "Streaming Status",
-      "UUID" : "00000120-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read",
-        "write",
-        "cnotify"
-      ],
       "Format" : "tlv8",
       "Permissions" : [
-        "securedRead",
-        "securedWrite"
-      ]
+        "securedRead"
+      ],
+      "Properties" : [
+        "read",
+        "cnotify"
+      ],
+      "UUID" : "00000120-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "000000C5-0000-1000-8000-0026BB765291",
+      "Name" : "Sulphur Dioxide Density",
+      "Format" : "float",
       "Constraints" : {
         "StepValue" : 1,
         "MaximumValue" : 1000,
         "MinimumValue" : 0
       },
-      "Name" : "Sulphur Dioxide Density",
-      "UUID" : "000000C5-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
       "Name" : "Supported Audio Stream Configuration",
-      "UUID" : "00000115-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
-      ],
       "Format" : "tlv8",
       "Permissions" : [
         "securedRead"
-      ]
+      ],
+      "Properties" : [
+        "read"
+      ],
+      "UUID" : "00000115-0000-1000-8000-0026BB765291"
     },
     {
       "Name" : "Supported RTP Configuration",
-      "UUID" : "00000116-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
-      ],
       "Format" : "tlv8",
       "Permissions" : [
         "securedRead"
-      ]
+      ],
+      "Properties" : [
+        "read"
+      ],
+      "UUID" : "00000116-0000-1000-8000-0026BB765291"
     },
     {
       "Name" : "Supported Video Stream Configuration",
-      "UUID" : "00000114-0000-1000-8000-0026BB765291",
-      "Properties" : [
-        "read"
-      ],
       "Format" : "tlv8",
       "Permissions" : [
         "securedRead"
-      ]
+      ],
+      "Properties" : [
+        "read"
+      ],
+      "UUID" : "00000114-0000-1000-8000-0026BB765291"
     },
     {
+      "UUID" : "000000B6-0000-1000-8000-0026BB765291",
+      "Name" : "Swing Mode",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
-          "0" : "Swing disabled",
-          "1" : "Swing enabled"
+          "0" : "Swing Disabled",
+          "1" : "Swing Enabled"
         }
       },
-      "Name" : "Swing Mode",
-      "UUID" : "000000B6-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
+      "UUID" : "000000A8-0000-1000-8000-0026BB765291",
+      "Name" : "Target Air Purifier State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Manual",
           "1" : "Auto"
         }
       },
-      "Name" : "Target Air Purifier State",
-      "UUID" : "000000A8-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
+      "UUID" : "000000AE-0000-1000-8000-0026BB765291",
+      "Name" : "Target Air Quality",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Excellent",
@@ -1796,60 +1802,60 @@
           "2" : "Fair"
         }
       },
-      "Name" : "Target Air Quality",
-      "UUID" : "000000AE-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
+      "UUID" : "00000032-0000-1000-8000-0026BB765291",
+      "Name" : "Target Door State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Open",
           "1" : "Closed"
         }
       },
-      "Name" : "Target Door State",
-      "UUID" : "00000032-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
+      "UUID" : "000000BF-0000-1000-8000-0026BB765291",
+      "Name" : "Target Fan State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Manual",
           "1" : "Auto"
         }
       },
-      "Name" : "Target Fan State",
-      "UUID" : "000000BF-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
+      "UUID" : "000000B2-0000-1000-8000-0026BB765291",
+      "Name" : "Target Heater Cooler State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Auto",
@@ -1857,20 +1863,20 @@
           "2" : "Cool"
         }
       },
-      "Name" : "Target Heater Cooler State",
-      "UUID" : "000000B2-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
+      "UUID" : "00000033-0000-1000-8000-0026BB765291",
+      "Name" : "Target Heating Cooling State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "3" : "Auto",
@@ -1879,17 +1885,14 @@
           "0" : "Off"
         }
       },
-      "Name" : "Target Heating Cooling State",
-      "UUID" : "00000033-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
@@ -1913,24 +1916,24 @@
       }
     },
     {
+      "UUID" : "000000B4-0000-1000-8000-0026BB765291",
+      "Name" : "Target Humidifier Dehumidifier State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
-          "0" : "Auto",
+          "0" : "Humidifier or Dehumidifier",
           "1" : "Humidifier",
           "2" : "Dehumidifier"
         }
       },
-      "Name" : "Target Humidifier Dehumidifier State",
-      "UUID" : "000000B4-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
@@ -1974,23 +1977,23 @@
       }
     },
     {
+      "UUID" : "000000BE-0000-1000-8000-0026BB765291",
+      "Name" : "Target Slat State",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Manual",
           "1" : "Auto"
         }
       },
-      "Name" : "Target Slat State",
-      "UUID" : "000000BE-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
@@ -2054,57 +2057,60 @@
       }
     },
     {
+      "UUID" : "00000036-0000-1000-8000-0026BB765291",
+      "Name" : "Temperature Display Units",
+      "Format" : "uint8",
       "Constraints" : {
         "ValidValues" : {
           "0" : "Celsius",
           "1" : "Fahrenheit"
         }
       },
-      "Name" : "Temperature Display Units",
-      "UUID" : "00000036-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead",
+        "securedWrite"
+      ],
       "Properties" : [
         "read",
         "write",
         "cnotify"
-      ],
-      "Format" : "uint8",
-      "Permissions" : [
-        "securedRead",
-        "securedWrite"
       ]
     },
     {
-      "Name" : "Version",
       "UUID" : "00000037-0000-1000-8000-0026BB765291",
+      "Name" : "Version",
+      "Format" : "string",
+      "Constraints" : {
+        "MaximumLength" : 64
+      },
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "string",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
+      "UUID" : "000000C8-0000-1000-8000-0026BB765291",
+      "Name" : "VOC Density",
+      "Format" : "float",
       "Constraints" : {
         "StepValue" : 1,
         "MaximumValue" : 1000,
         "MinimumValue" : 0
       },
-      "Name" : "VOC Density",
-      "UUID" : "000000C8-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify",
         "uncnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead"
       ]
     },
     {
-      "Format" : "float",
+      "Format" : "uint8",
       "UUID" : "00000119-0000-1000-8000-0026BB765291",
       "Properties" : [
         "read",
@@ -2124,19 +2130,19 @@
       }
     },
     {
+      "UUID" : "000000B5-0000-1000-8000-0026BB765291",
+      "Name" : "Water Level",
+      "Format" : "float",
       "Constraints" : {
         "MaximumValue" : 100,
         "MinimumValue" : 0
       },
-      "Name" : "Water Level",
-      "UUID" : "000000B5-0000-1000-8000-0026BB765291",
+      "Permissions" : [
+        "securedRead"
+      ],
       "Properties" : [
         "read",
         "cnotify"
-      ],
-      "Format" : "float",
-      "Permissions" : [
-        "securedRead"
       ]
     }
   ],
@@ -2148,14 +2154,12 @@
         "00000020-0000-1000-8000-0026BB765291",
         "00000021-0000-1000-8000-0026BB765291",
         "00000023-0000-1000-8000-0026BB765291",
-        "00000030-0000-1000-8000-0026BB765291"
+        "00000030-0000-1000-8000-0026BB765291",
+        "00000052-0000-1000-8000-0026BB765291"
       ],
       "OptionalCharacteristics" : [
-        "00000052-0000-1000-8000-0026BB765291",
         "00000053-0000-1000-8000-0026BB765291",
-        "00000054-0000-1000-8000-0026BB765291",
-        "000000A6-0000-1000-8000-0026BB765291",
-        "000000A4-0000-1000-8000-0026BB765291"
+        "000000A6-0000-1000-8000-0026BB765291"
       ],
       "Name" : "Accessory Information",
       "UUID" : "0000003E-0000-1000-8000-0026BB765291"
@@ -2208,25 +2212,6 @@
       ],
       "Name" : "Battery Service",
       "UUID" : "00000096-0000-1000-8000-0026BB765291"
-    },
-    {
-      "RequiredCharacteristics" : [
-        "00000025-0000-1000-8000-0026BB765291"
-      ],
-      "OptionalCharacteristics" : [
-        "0000006C-0000-1000-8000-0026BB765291",
-        "0000006E-0000-1000-8000-0026BB765291",
-        "0000007B-0000-1000-8000-0026BB765291",
-        "0000007D-0000-1000-8000-0026BB765291",
-        "0000011B-0000-1000-8000-0026BB765291",
-        "0000011C-0000-1000-8000-0026BB765291",
-        "0000011D-0000-1000-8000-0026BB765291",
-        "0000011E-0000-1000-8000-0026BB765291",
-        "0000011F-0000-1000-8000-0026BB765291",
-        "00000023-0000-1000-8000-0026BB765291"
-      ],
-      "Name" : "Camera Control",
-      "UUID" : "00000111-0000-1000-8000-0026BB765291"
     },
     {
       "RequiredCharacteristics" : [
@@ -2557,6 +2542,16 @@
     },
     {
       "RequiredCharacteristics" : [
+        "000000CD-0000-1000-8000-0026BB765291"
+      ],
+      "OptionalCharacteristics" : [
+        "00000023-0000-1000-8000-0026BB765291"
+      ],
+      "Name" : "Service Label",
+      "UUID" : "000000CC-0000-1000-8000-0026BB765291"
+    },
+    {
+      "RequiredCharacteristics" : [
         "000000C0-0000-1000-8000-0026BB765291",
         "000000AA-0000-1000-8000-0026BB765291"
       ],
@@ -2596,21 +2591,11 @@
     },
     {
       "RequiredCharacteristics" : [
-        "00000073-0000-1000-8000-0026BB765291",
-        "00000074-0000-1000-8000-0026BB765291"
-      ],
-      "OptionalCharacteristics" : [
-        "00000023-0000-1000-8000-0026BB765291"
-      ],
-      "Name" : "Stateful Programmable Switch",
-      "UUID" : "00000088-0000-1000-8000-0026BB765291"
-    },
-    {
-      "RequiredCharacteristics" : [
         "00000073-0000-1000-8000-0026BB765291"
       ],
       "OptionalCharacteristics" : [
-        "00000023-0000-1000-8000-0026BB765291"
+        "00000023-0000-1000-8000-0026BB765291",
+        "000000CB-0000-1000-8000-0026BB765291"
       ],
       "Name" : "Stateless Programmable Switch",
       "UUID" : "00000089-0000-1000-8000-0026BB765291"

--- a/node_modules/has-node/src/predefinedTypes/predefined.d.ts
+++ b/node_modules/has-node/src/predefinedTypes/predefined.d.ts
@@ -7,7 +7,6 @@ export declare function AdministratorOnlyAccess(ID: number, value: any, onWrite?
 export declare function AirParticulateDensity(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function AirParticulateSize(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function AirQuality(ID: number, value: any, onWrite?: OnWrite): Characteristic;
-export declare function AppMatchingIdentifier(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function AudioFeedback(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function BatteryLevel(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function Brightness(ID: number, value: any, onWrite?: OnWrite): Characteristic;
@@ -18,6 +17,7 @@ export declare function CarbonMonoxideDetected(ID: number, value: any, onWrite?:
 export declare function CarbonMonoxideLevel(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function CarbonMonoxidePeakLevel(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function ChargingState(ID: number, value: any, onWrite?: OnWrite): Characteristic;
+export declare function ColorTemperature(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function ContactSensorState(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function CoolingThresholdTemperature(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function CurrentAirPurifierState(ID: number, value: any, onWrite?: OnWrite): Characteristic;
@@ -55,8 +55,8 @@ export declare function LockTargetState(ID: number, value: any, onWrite?: OnWrit
 export declare function Logs(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function Manufacturer(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function Model(ID: number, value: any, onWrite?: OnWrite): Characteristic;
-export declare function Mute(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function MotionDetected(ID: number, value: any, onWrite?: OnWrite): Characteristic;
+export declare function Mute(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function Name(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function NightVision(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function NitrogenDioxideDensity(ID: number, value: any, onWrite?: OnWrite): Characteristic;
@@ -74,7 +74,6 @@ export declare function PM10Density(ID: number, value: any, onWrite?: OnWrite): 
 export declare function PM25Density(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function PositionState(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function ProgrammableSwitchEvent(ID: number, value: any, onWrite?: OnWrite): Characteristic;
-export declare function ProgrammableSwitchOutputState(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function RelativeHumidityDehumidifierThreshold(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function RelativeHumidityHumidifierThreshold(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function ResetFilterIndication(ID: number, value: any, onWrite?: OnWrite): Characteristic;
@@ -84,12 +83,13 @@ export declare function Saturation(ID: number, value: any, onWrite?: OnWrite): C
 export declare function SecuritySystemAlarmType(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function SecuritySystemCurrentState(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function SecuritySystemTargetState(ID: number, value: any, onWrite?: OnWrite): Characteristic;
-export declare function SelectedStreamConfiguration(ID: number, value: any, onWrite?: OnWrite): Characteristic;
+export declare function SelectedRTPStreamConfiguration(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function SerialNumber(ID: number, value: any, onWrite?: OnWrite): Characteristic;
+export declare function ServiceLabelIndex(ID: number, value: any, onWrite?: OnWrite): Characteristic;
+export declare function ServiceLabelNamespace(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function SetupEndpoints(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function SlatType(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function SmokeDetected(ID: number, value: any, onWrite?: OnWrite): Characteristic;
-export declare function SoftwareRevision(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function StatusActive(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function StatusFault(ID: number, value: any, onWrite?: OnWrite): Characteristic;
 export declare function StatusJammed(ID: number, value: any, onWrite?: OnWrite): Characteristic;
@@ -124,7 +124,6 @@ export declare function AccessoryInformation(ID: number, characteristics: Charac
 export declare function AirPurifier(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function AirQualitySensor(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function BatteryService(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
-export declare function CameraControl(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function CameraRTPStreamManagement(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function CarbonDioxideSensor(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function CarbonMonoxideSensor(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
@@ -148,10 +147,10 @@ export declare function MotionSensor(ID: number, characteristics: Characteristic
 export declare function OccupancySensor(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function Outlet(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function SecuritySystem(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
+export declare function ServiceLabel(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function Slat(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function SmokeSensor(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function Speaker(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
-export declare function StatefulProgrammableSwitch(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function StatelessProgrammableSwitch(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function Switch(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;
 export declare function TemperatureSensor(ID: number, characteristics: Characteristic[], isHidden?: boolean, isPrimary?: boolean, linkedServices?: number[]): Service;

--- a/node_modules/has-node/src/predefinedTypes/predefined.js
+++ b/node_modules/has-node/src/predefinedTypes/predefined.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var characteristic_1 = require("../characteristic");
 var service_1 = require("../service");
 function AccessoryFlags(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '000000A6-0000-1000-8000-0026BB765291', 'uint32', false, true, true, true, false, undefined, "Accessory Flags", undefined, undefined, undefined, undefined, [0], undefined);
+    var characteristic = new characteristic_1.default(ID, '000000A6-0000-1000-8000-0026BB765291', 'uint32', false, true, true, true, false, undefined, "Accessory Flags", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -56,15 +56,6 @@ function AirQuality(ID, value, onWrite) {
     return characteristic;
 }
 exports.AirQuality = AirQuality;
-function AppMatchingIdentifier(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '000000A4-0000-1000-8000-0026BB765291', 'tlv8', false, false, true, true, false, undefined, "App Matching Identifier", undefined, undefined, undefined, undefined, undefined, undefined);
-    if (value != null && value != undefined)
-        characteristic.setValue(value);
-    if (onWrite)
-        characteristic.onWrite = onWrite;
-    return characteristic;
-}
-exports.AppMatchingIdentifier = AppMatchingIdentifier;
 function AudioFeedback(ID, value, onWrite) {
     var characteristic = new characteristic_1.default(ID, '00000005-0000-1000-8000-0026BB765291', 'bool', false, true, true, false, false, undefined, "Audio Feedback", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
@@ -102,7 +93,7 @@ function CarbonDioxideDetected(ID, value, onWrite) {
 }
 exports.CarbonDioxideDetected = CarbonDioxideDetected;
 function CarbonDioxideLevel(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000093-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Dioxide Level", 0, 100000, 100, undefined, undefined, undefined);
+    var characteristic = new characteristic_1.default(ID, '00000093-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Dioxide Level", 0, 100000, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -111,7 +102,7 @@ function CarbonDioxideLevel(ID, value, onWrite) {
 }
 exports.CarbonDioxideLevel = CarbonDioxideLevel;
 function CarbonDioxidePeakLevel(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000094-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Dioxide Peak Level", 0, 100000, 100, undefined, undefined, undefined);
+    var characteristic = new characteristic_1.default(ID, '00000094-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Dioxide Peak Level", 0, 100000, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -129,7 +120,7 @@ function CarbonMonoxideDetected(ID, value, onWrite) {
 }
 exports.CarbonMonoxideDetected = CarbonMonoxideDetected;
 function CarbonMonoxideLevel(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000090-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Monoxide Level", 0, 100, 0.1, undefined, undefined, undefined);
+    var characteristic = new characteristic_1.default(ID, '00000090-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Monoxide Level", 0, 100, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -138,7 +129,7 @@ function CarbonMonoxideLevel(ID, value, onWrite) {
 }
 exports.CarbonMonoxideLevel = CarbonMonoxideLevel;
 function CarbonMonoxidePeakLevel(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000091-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Monoxide Peak Level", 0, 100, 0.1, undefined, undefined, undefined);
+    var characteristic = new characteristic_1.default(ID, '00000091-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Monoxide Peak Level", 0, 100, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -155,6 +146,15 @@ function ChargingState(ID, value, onWrite) {
     return characteristic;
 }
 exports.ChargingState = ChargingState;
+function ColorTemperature(ID, value, onWrite) {
+    var characteristic = new characteristic_1.default(ID, '000000CE-0000-1000-8000-0026BB765291', 'uint32', false, true, true, false, false, undefined, "Color Temperature", 140, 500, 1, undefined, undefined, undefined);
+    if (value != null && value != undefined)
+        characteristic.setValue(value);
+    if (onWrite)
+        characteristic.onWrite = onWrite;
+    return characteristic;
+}
+exports.ColorTemperature = ColorTemperature;
 function ContactSensorState(ID, value, onWrite) {
     var characteristic = new characteristic_1.default(ID, '0000006A-0000-1000-8000-0026BB765291', 'uint8', false, true, true, true, false, undefined, "Contact Sensor State", undefined, undefined, undefined, undefined, [0, 1], undefined);
     if (value != null && value != undefined)
@@ -183,7 +183,7 @@ function CurrentAirPurifierState(ID, value, onWrite) {
 }
 exports.CurrentAirPurifierState = CurrentAirPurifierState;
 function CurrentAmbientLightLevel(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '0000006B-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, "lux", "Current Ambient Light Level", 0.0001, 100000, 0.0001, undefined, undefined, undefined);
+    var characteristic = new characteristic_1.default(ID, '0000006B-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, "lux", "Current Ambient Light Level", 0.0001, 100000, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -435,7 +435,7 @@ function LockLastKnownAction(ID, value, onWrite) {
 }
 exports.LockLastKnownAction = LockLastKnownAction;
 function LockManagementAutoSecurityTimeout(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '0000001A-0000-1000-8000-0026BB765291', 'uint32', false, true, true, false, false, "seconds", "Lock Management Auto Security Timeout", 0, 86400, 1, undefined, undefined, undefined);
+    var characteristic = new characteristic_1.default(ID, '0000001A-0000-1000-8000-0026BB765291', 'uint32', false, true, true, false, false, "seconds", "Lock Management Auto Security Timeout", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -488,15 +488,6 @@ function Model(ID, value, onWrite) {
     return characteristic;
 }
 exports.Model = Model;
-function Mute(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '0000011A-0000-1000-8000-0026BB765291', 'bool', false, true, true, false, false, undefined, "Mute", undefined, undefined, undefined, undefined, undefined, undefined);
-    if (value != null && value != undefined)
-        characteristic.setValue(value);
-    if (onWrite)
-        characteristic.onWrite = onWrite;
-    return characteristic;
-}
-exports.Mute = Mute;
 function MotionDetected(ID, value, onWrite) {
     var characteristic = new characteristic_1.default(ID, '00000022-0000-1000-8000-0026BB765291', 'bool', false, true, true, true, false, undefined, "Motion Detected", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
@@ -506,6 +497,15 @@ function MotionDetected(ID, value, onWrite) {
     return characteristic;
 }
 exports.MotionDetected = MotionDetected;
+function Mute(ID, value, onWrite) {
+    var characteristic = new characteristic_1.default(ID, '0000011A-0000-1000-8000-0026BB765291', 'bool', false, true, true, false, false, undefined, "Mute", undefined, undefined, undefined, undefined, undefined, undefined);
+    if (value != null && value != undefined)
+        characteristic.setValue(value);
+    if (onWrite)
+        characteristic.onWrite = onWrite;
+    return characteristic;
+}
+exports.Mute = Mute;
 function Name(ID, value, onWrite) {
     var characteristic = new characteristic_1.default(ID, '00000023-0000-1000-8000-0026BB765291', 'string', false, false, true, true, false, undefined, "Name", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
@@ -651,7 +651,7 @@ function PositionState(ID, value, onWrite) {
 }
 exports.PositionState = PositionState;
 function ProgrammableSwitchEvent(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000073-0000-1000-8000-0026BB765291', 'uint8', false, true, true, true, false, undefined, "Programmable Switch Event", 0, 1, 1, undefined, undefined, undefined);
+    var characteristic = new characteristic_1.default(ID, '00000073-0000-1000-8000-0026BB765291', 'uint8', false, true, true, true, false, undefined, "Programmable Switch Event", undefined, undefined, undefined, undefined, [0, 1, 2], undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -659,15 +659,6 @@ function ProgrammableSwitchEvent(ID, value, onWrite) {
     return characteristic;
 }
 exports.ProgrammableSwitchEvent = ProgrammableSwitchEvent;
-function ProgrammableSwitchOutputState(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000074-0000-1000-8000-0026BB765291', 'uint8', false, true, true, false, false, undefined, "Programmable Switch Output State", 0, 1, 1, undefined, undefined, undefined);
-    if (value != null && value != undefined)
-        characteristic.setValue(value);
-    if (onWrite)
-        characteristic.onWrite = onWrite;
-    return characteristic;
-}
-exports.ProgrammableSwitchOutputState = ProgrammableSwitchOutputState;
 function RelativeHumidityDehumidifierThreshold(ID, value, onWrite) {
     var characteristic = new characteristic_1.default(ID, '000000C9-0000-1000-8000-0026BB765291', 'float', false, true, true, false, false, undefined, "Relative Humidity Dehumidifier Threshold", 0, 100, 1, undefined, undefined, undefined);
     if (value != null && value != undefined)
@@ -749,15 +740,15 @@ function SecuritySystemTargetState(ID, value, onWrite) {
     return characteristic;
 }
 exports.SecuritySystemTargetState = SecuritySystemTargetState;
-function SelectedStreamConfiguration(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000117-0000-1000-8000-0026BB765291', 'tlv8', false, false, true, false, false, undefined, "Selected Stream Configuration", undefined, undefined, undefined, undefined, undefined, undefined);
+function SelectedRTPStreamConfiguration(ID, value, onWrite) {
+    var characteristic = new characteristic_1.default(ID, '00000117-0000-1000-8000-0026BB765291', 'tlv8', false, false, true, false, false, undefined, "Selected RTP Stream Configuration", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
         characteristic.onWrite = onWrite;
     return characteristic;
 }
-exports.SelectedStreamConfiguration = SelectedStreamConfiguration;
+exports.SelectedRTPStreamConfiguration = SelectedRTPStreamConfiguration;
 function SerialNumber(ID, value, onWrite) {
     var characteristic = new characteristic_1.default(ID, '00000030-0000-1000-8000-0026BB765291', 'string', false, false, true, true, false, undefined, "Serial Number", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
@@ -767,8 +758,26 @@ function SerialNumber(ID, value, onWrite) {
     return characteristic;
 }
 exports.SerialNumber = SerialNumber;
+function ServiceLabelIndex(ID, value, onWrite) {
+    var characteristic = new characteristic_1.default(ID, '000000CB-0000-1000-8000-0026BB765291', 'uint8', false, false, true, true, false, undefined, "Service Label Index", 1, 255, 1, undefined, undefined, undefined);
+    if (value != null && value != undefined)
+        characteristic.setValue(value);
+    if (onWrite)
+        characteristic.onWrite = onWrite;
+    return characteristic;
+}
+exports.ServiceLabelIndex = ServiceLabelIndex;
+function ServiceLabelNamespace(ID, value, onWrite) {
+    var characteristic = new characteristic_1.default(ID, '000000CD-0000-1000-8000-0026BB765291', 'uint8', false, false, true, true, false, undefined, "Service Label Namespace", undefined, undefined, undefined, undefined, [0, 1], undefined);
+    if (value != null && value != undefined)
+        characteristic.setValue(value);
+    if (onWrite)
+        characteristic.onWrite = onWrite;
+    return characteristic;
+}
+exports.ServiceLabelNamespace = ServiceLabelNamespace;
 function SetupEndpoints(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000118-0000-1000-8000-0026BB765291', 'tlv8', false, true, true, false, false, undefined, "Setup Endpoints", undefined, undefined, undefined, undefined, undefined, undefined);
+    var characteristic = new characteristic_1.default(ID, '00000118-0000-1000-8000-0026BB765291', 'tlv8', false, false, true, false, false, undefined, "Setup Endpoints", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -777,7 +786,7 @@ function SetupEndpoints(ID, value, onWrite) {
 }
 exports.SetupEndpoints = SetupEndpoints;
 function SlatType(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '000000C0-0000-1000-8000-0026BB765291', 'uint8', false, true, true, true, false, undefined, "Slat Type", undefined, undefined, undefined, undefined, [0, 1], undefined);
+    var characteristic = new characteristic_1.default(ID, '000000C0-0000-1000-8000-0026BB765291', 'uint8', false, false, true, true, false, undefined, "Slat Type", undefined, undefined, undefined, undefined, [0, 1], undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -794,15 +803,6 @@ function SmokeDetected(ID, value, onWrite) {
     return characteristic;
 }
 exports.SmokeDetected = SmokeDetected;
-function SoftwareRevision(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000054-0000-1000-8000-0026BB765291', 'string', false, false, true, true, false, undefined, "Software Revision", undefined, undefined, undefined, undefined, undefined, undefined);
-    if (value != null && value != undefined)
-        characteristic.setValue(value);
-    if (onWrite)
-        characteristic.onWrite = onWrite;
-    return characteristic;
-}
-exports.SoftwareRevision = SoftwareRevision;
 function StatusActive(ID, value, onWrite) {
     var characteristic = new characteristic_1.default(ID, '00000075-0000-1000-8000-0026BB765291', 'bool', false, true, true, true, false, undefined, "Status Active", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
@@ -849,7 +849,7 @@ function StatusTampered(ID, value, onWrite) {
 }
 exports.StatusTampered = StatusTampered;
 function StreamingStatus(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000120-0000-1000-8000-0026BB765291', 'tlv8', false, true, true, false, false, undefined, "Streaming Status", undefined, undefined, undefined, undefined, undefined, undefined);
+    var characteristic = new characteristic_1.default(ID, '00000120-0000-1000-8000-0026BB765291', 'tlv8', false, true, true, true, false, undefined, "Streaming Status", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -1056,7 +1056,7 @@ function VOCDensity(ID, value, onWrite) {
 }
 exports.VOCDensity = VOCDensity;
 function Volume(ID, value, onWrite) {
-    var characteristic = new characteristic_1.default(ID, '00000119-0000-1000-8000-0026BB765291', 'float', false, true, true, false, false, "percentage", "Volume", 0, 100, 1, undefined, undefined, undefined);
+    var characteristic = new characteristic_1.default(ID, '00000119-0000-1000-8000-0026BB765291', 'uint8', false, true, true, false, false, "percentage", "Volume", 0, 100, 1, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -1078,8 +1078,8 @@ function AccessoryInformation(ID, characteristics, isHidden, isPrimary, linkedSe
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
     var service = new service_1.default(ID, '0000003E-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000014-0000-1000-8000-0026BB765291', '00000020-0000-1000-8000-0026BB765291', '00000021-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '00000030-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000052-0000-1000-8000-0026BB765291', '00000053-0000-1000-8000-0026BB765291', '00000054-0000-1000-8000-0026BB765291', '000000A6-0000-1000-8000-0026BB765291', '000000A4-0000-1000-8000-0026BB765291'];
+    var requiredCharacteristics = ['00000014-0000-1000-8000-0026BB765291', '00000020-0000-1000-8000-0026BB765291', '00000021-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '00000030-0000-1000-8000-0026BB765291', '00000052-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000053-0000-1000-8000-0026BB765291', '000000A6-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_1 = requiredCharacteristics; _i < requiredCharacteristics_1.length; _i++) {
         var type = requiredCharacteristics_1[_i];
         var OK = false;
@@ -1189,13 +1189,13 @@ function BatteryService(ID, characteristics, isHidden, isPrimary, linkedServices
     return service;
 }
 exports.BatteryService = BatteryService;
-function CameraControl(ID, characteristics, isHidden, isPrimary, linkedServices) {
+function CameraRTPStreamManagement(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000111-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000025-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['0000006C-0000-1000-8000-0026BB765291', '0000006E-0000-1000-8000-0026BB765291', '0000007B-0000-1000-8000-0026BB765291', '0000007D-0000-1000-8000-0026BB765291', '0000011B-0000-1000-8000-0026BB765291', '0000011C-0000-1000-8000-0026BB765291', '0000011D-0000-1000-8000-0026BB765291', '0000011E-0000-1000-8000-0026BB765291', '0000011F-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000110-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000114-0000-1000-8000-0026BB765291', '00000115-0000-1000-8000-0026BB765291', '00000116-0000-1000-8000-0026BB765291', '00000117-0000-1000-8000-0026BB765291', '00000120-0000-1000-8000-0026BB765291', '00000118-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_5 = requiredCharacteristics; _i < requiredCharacteristics_5.length; _i++) {
         var type = requiredCharacteristics_5[_i];
         var OK = false;
@@ -1217,14 +1217,14 @@ function CameraControl(ID, characteristics, isHidden, isPrimary, linkedServices)
     }
     return service;
 }
-exports.CameraControl = CameraControl;
-function CameraRTPStreamManagement(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.CameraRTPStreamManagement = CameraRTPStreamManagement;
+function CarbonDioxideSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000110-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000114-0000-1000-8000-0026BB765291', '00000115-0000-1000-8000-0026BB765291', '00000116-0000-1000-8000-0026BB765291', '00000117-0000-1000-8000-0026BB765291', '00000120-0000-1000-8000-0026BB765291', '00000118-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000097-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000092-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000093-0000-1000-8000-0026BB765291', '00000094-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_6 = requiredCharacteristics; _i < requiredCharacteristics_6.length; _i++) {
         var type = requiredCharacteristics_6[_i];
         var OK = false;
@@ -1246,14 +1246,14 @@ function CameraRTPStreamManagement(ID, characteristics, isHidden, isPrimary, lin
     }
     return service;
 }
-exports.CameraRTPStreamManagement = CameraRTPStreamManagement;
-function CarbonDioxideSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.CarbonDioxideSensor = CarbonDioxideSensor;
+function CarbonMonoxideSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000097-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000092-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000093-0000-1000-8000-0026BB765291', '00000094-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '0000007F-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000069-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000090-0000-1000-8000-0026BB765291', '00000091-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_7 = requiredCharacteristics; _i < requiredCharacteristics_7.length; _i++) {
         var type = requiredCharacteristics_7[_i];
         var OK = false;
@@ -1275,14 +1275,14 @@ function CarbonDioxideSensor(ID, characteristics, isHidden, isPrimary, linkedSer
     }
     return service;
 }
-exports.CarbonDioxideSensor = CarbonDioxideSensor;
-function CarbonMonoxideSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.CarbonMonoxideSensor = CarbonMonoxideSensor;
+function ContactSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '0000007F-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000069-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000090-0000-1000-8000-0026BB765291', '00000091-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000080-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['0000006A-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_8 = requiredCharacteristics; _i < requiredCharacteristics_8.length; _i++) {
         var type = requiredCharacteristics_8[_i];
         var OK = false;
@@ -1304,14 +1304,14 @@ function CarbonMonoxideSensor(ID, characteristics, isHidden, isPrimary, linkedSe
     }
     return service;
 }
-exports.CarbonMonoxideSensor = CarbonMonoxideSensor;
-function ContactSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.ContactSensor = ContactSensor;
+function Door(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000080-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['0000006A-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000081-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['0000006D-0000-1000-8000-0026BB765291', '00000072-0000-1000-8000-0026BB765291', '0000007C-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['0000006F-0000-1000-8000-0026BB765291', '00000024-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_9 = requiredCharacteristics; _i < requiredCharacteristics_9.length; _i++) {
         var type = requiredCharacteristics_9[_i];
         var OK = false;
@@ -1333,14 +1333,14 @@ function ContactSensor(ID, characteristics, isHidden, isPrimary, linkedServices)
     }
     return service;
 }
-exports.ContactSensor = ContactSensor;
-function Door(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.Door = Door;
+function Doorbell(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000081-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['0000006D-0000-1000-8000-0026BB765291', '00000072-0000-1000-8000-0026BB765291', '0000007C-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['0000006F-0000-1000-8000-0026BB765291', '00000024-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000121-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000073-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000008-0000-1000-8000-0026BB765291', '00000119-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_10 = requiredCharacteristics; _i < requiredCharacteristics_10.length; _i++) {
         var type = requiredCharacteristics_10[_i];
         var OK = false;
@@ -1362,14 +1362,14 @@ function Door(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.Door = Door;
-function Doorbell(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.Doorbell = Doorbell;
+function Fan(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000121-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000073-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000008-0000-1000-8000-0026BB765291', '00000119-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000040-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000025-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000028-0000-1000-8000-0026BB765291', '00000029-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_11 = requiredCharacteristics; _i < requiredCharacteristics_11.length; _i++) {
         var type = requiredCharacteristics_11[_i];
         var OK = false;
@@ -1391,14 +1391,14 @@ function Doorbell(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.Doorbell = Doorbell;
-function Fan(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.Fan = Fan;
+function Fanv2(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000040-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000025-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000028-0000-1000-8000-0026BB765291', '00000029-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '000000B7-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['000000B0-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['000000AF-0000-1000-8000-0026BB765291', '000000BF-0000-1000-8000-0026BB765291', '000000A7-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '00000028-0000-1000-8000-0026BB765291', '00000029-0000-1000-8000-0026BB765291', '000000B6-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_12 = requiredCharacteristics; _i < requiredCharacteristics_12.length; _i++) {
         var type = requiredCharacteristics_12[_i];
         var OK = false;
@@ -1420,14 +1420,14 @@ function Fan(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.Fan = Fan;
-function Fanv2(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.Fanv2 = Fanv2;
+function FilterMaintenance(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '000000B7-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['000000B0-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['000000AF-0000-1000-8000-0026BB765291', '000000BF-0000-1000-8000-0026BB765291', '000000A7-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '00000028-0000-1000-8000-0026BB765291', '00000029-0000-1000-8000-0026BB765291', '000000B6-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '000000BA-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['000000AC-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['000000AB-0000-1000-8000-0026BB765291', '000000AD-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_13 = requiredCharacteristics; _i < requiredCharacteristics_13.length; _i++) {
         var type = requiredCharacteristics_13[_i];
         var OK = false;
@@ -1449,14 +1449,14 @@ function Fanv2(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.Fanv2 = Fanv2;
-function FilterMaintenance(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.FilterMaintenance = FilterMaintenance;
+function GarageDoorOpener(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '000000BA-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['000000AC-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['000000AB-0000-1000-8000-0026BB765291', '000000AD-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000041-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['0000000E-0000-1000-8000-0026BB765291', '00000032-0000-1000-8000-0026BB765291', '00000024-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['0000001D-0000-1000-8000-0026BB765291', '0000001E-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_14 = requiredCharacteristics; _i < requiredCharacteristics_14.length; _i++) {
         var type = requiredCharacteristics_14[_i];
         var OK = false;
@@ -1478,14 +1478,14 @@ function FilterMaintenance(ID, characteristics, isHidden, isPrimary, linkedServi
     }
     return service;
 }
-exports.FilterMaintenance = FilterMaintenance;
-function GarageDoorOpener(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.GarageDoorOpener = GarageDoorOpener;
+function HeaterCooler(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000041-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['0000000E-0000-1000-8000-0026BB765291', '00000032-0000-1000-8000-0026BB765291', '00000024-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['0000001D-0000-1000-8000-0026BB765291', '0000001E-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '000000BC-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['000000B0-0000-1000-8000-0026BB765291', '000000B1-0000-1000-8000-0026BB765291', '000000B2-0000-1000-8000-0026BB765291', '00000011-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['000000A7-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '000000B6-0000-1000-8000-0026BB765291', '0000000D-0000-1000-8000-0026BB765291', '00000012-0000-1000-8000-0026BB765291', '00000036-0000-1000-8000-0026BB765291', '00000029-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_15 = requiredCharacteristics; _i < requiredCharacteristics_15.length; _i++) {
         var type = requiredCharacteristics_15[_i];
         var OK = false;
@@ -1507,14 +1507,14 @@ function GarageDoorOpener(ID, characteristics, isHidden, isPrimary, linkedServic
     }
     return service;
 }
-exports.GarageDoorOpener = GarageDoorOpener;
-function HeaterCooler(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.HeaterCooler = HeaterCooler;
+function HumidifierDehumidifier(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '000000BC-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['000000B0-0000-1000-8000-0026BB765291', '000000B1-0000-1000-8000-0026BB765291', '000000B2-0000-1000-8000-0026BB765291', '00000011-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['000000A7-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '000000B6-0000-1000-8000-0026BB765291', '0000000D-0000-1000-8000-0026BB765291', '00000012-0000-1000-8000-0026BB765291', '00000036-0000-1000-8000-0026BB765291', '00000029-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '000000BD-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000010-0000-1000-8000-0026BB765291', '000000B3-0000-1000-8000-0026BB765291', '000000B4-0000-1000-8000-0026BB765291', '000000B0-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['000000A7-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '000000B6-0000-1000-8000-0026BB765291', '000000B5-0000-1000-8000-0026BB765291', '000000C9-0000-1000-8000-0026BB765291', '000000CA-0000-1000-8000-0026BB765291', '00000029-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_16 = requiredCharacteristics; _i < requiredCharacteristics_16.length; _i++) {
         var type = requiredCharacteristics_16[_i];
         var OK = false;
@@ -1536,14 +1536,14 @@ function HeaterCooler(ID, characteristics, isHidden, isPrimary, linkedServices) 
     }
     return service;
 }
-exports.HeaterCooler = HeaterCooler;
-function HumidifierDehumidifier(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.HumidifierDehumidifier = HumidifierDehumidifier;
+function HumiditySensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '000000BD-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000010-0000-1000-8000-0026BB765291', '000000B3-0000-1000-8000-0026BB765291', '000000B4-0000-1000-8000-0026BB765291', '000000B0-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['000000A7-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '000000B6-0000-1000-8000-0026BB765291', '000000B5-0000-1000-8000-0026BB765291', '000000C9-0000-1000-8000-0026BB765291', '000000CA-0000-1000-8000-0026BB765291', '00000029-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000082-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000010-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_17 = requiredCharacteristics; _i < requiredCharacteristics_17.length; _i++) {
         var type = requiredCharacteristics_17[_i];
         var OK = false;
@@ -1565,13 +1565,13 @@ function HumidifierDehumidifier(ID, characteristics, isHidden, isPrimary, linked
     }
     return service;
 }
-exports.HumidifierDehumidifier = HumidifierDehumidifier;
-function HumiditySensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.HumiditySensor = HumiditySensor;
+function LeakSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000082-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000010-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000083-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000070-0000-1000-8000-0026BB765291'];
     var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_18 = requiredCharacteristics; _i < requiredCharacteristics_18.length; _i++) {
         var type = requiredCharacteristics_18[_i];
@@ -1594,13 +1594,13 @@ function HumiditySensor(ID, characteristics, isHidden, isPrimary, linkedServices
     }
     return service;
 }
-exports.HumiditySensor = HumiditySensor;
-function LeakSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.LeakSensor = LeakSensor;
+function LightSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000083-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000070-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000084-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['0000006B-0000-1000-8000-0026BB765291'];
     var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_19 = requiredCharacteristics; _i < requiredCharacteristics_19.length; _i++) {
         var type = requiredCharacteristics_19[_i];
@@ -1623,14 +1623,14 @@ function LeakSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.LeakSensor = LeakSensor;
-function LightSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.LightSensor = LightSensor;
+function Lightbulb(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000084-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['0000006B-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000043-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000025-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000008-0000-1000-8000-0026BB765291', '00000013-0000-1000-8000-0026BB765291', '0000002F-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '000000CE-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_20 = requiredCharacteristics; _i < requiredCharacteristics_20.length; _i++) {
         var type = requiredCharacteristics_20[_i];
         var OK = false;
@@ -1652,14 +1652,14 @@ function LightSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.LightSensor = LightSensor;
-function Lightbulb(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.Lightbulb = Lightbulb;
+function LockManagement(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000043-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000025-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000008-0000-1000-8000-0026BB765291', '00000013-0000-1000-8000-0026BB765291', '0000002F-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000044-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000019-0000-1000-8000-0026BB765291', '00000037-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['0000001F-0000-1000-8000-0026BB765291', '00000005-0000-1000-8000-0026BB765291', '0000001A-0000-1000-8000-0026BB765291', '00000001-0000-1000-8000-0026BB765291', '0000001C-0000-1000-8000-0026BB765291', '0000000E-0000-1000-8000-0026BB765291', '00000022-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_21 = requiredCharacteristics; _i < requiredCharacteristics_21.length; _i++) {
         var type = requiredCharacteristics_21[_i];
         var OK = false;
@@ -1681,14 +1681,14 @@ function Lightbulb(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.Lightbulb = Lightbulb;
-function LockManagement(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.LockManagement = LockManagement;
+function LockMechanism(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000044-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000019-0000-1000-8000-0026BB765291', '00000037-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['0000001F-0000-1000-8000-0026BB765291', '00000005-0000-1000-8000-0026BB765291', '0000001A-0000-1000-8000-0026BB765291', '00000001-0000-1000-8000-0026BB765291', '0000001C-0000-1000-8000-0026BB765291', '0000000E-0000-1000-8000-0026BB765291', '00000022-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000045-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['0000001D-0000-1000-8000-0026BB765291', '0000001E-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_22 = requiredCharacteristics; _i < requiredCharacteristics_22.length; _i++) {
         var type = requiredCharacteristics_22[_i];
         var OK = false;
@@ -1710,14 +1710,14 @@ function LockManagement(ID, characteristics, isHidden, isPrimary, linkedServices
     }
     return service;
 }
-exports.LockManagement = LockManagement;
-function LockMechanism(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.LockMechanism = LockMechanism;
+function Microphone(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000045-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['0000001D-0000-1000-8000-0026BB765291', '0000001E-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000112-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['0000011A-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000119-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_23 = requiredCharacteristics; _i < requiredCharacteristics_23.length; _i++) {
         var type = requiredCharacteristics_23[_i];
         var OK = false;
@@ -1739,14 +1739,14 @@ function LockMechanism(ID, characteristics, isHidden, isPrimary, linkedServices)
     }
     return service;
 }
-exports.LockMechanism = LockMechanism;
-function Microphone(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.Microphone = Microphone;
+function MotionSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000112-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['0000011A-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000119-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000085-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000022-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_24 = requiredCharacteristics; _i < requiredCharacteristics_24.length; _i++) {
         var type = requiredCharacteristics_24[_i];
         var OK = false;
@@ -1768,13 +1768,13 @@ function Microphone(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.Microphone = Microphone;
-function MotionSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.MotionSensor = MotionSensor;
+function OccupancySensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000085-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000022-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000086-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000071-0000-1000-8000-0026BB765291'];
     var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_25 = requiredCharacteristics; _i < requiredCharacteristics_25.length; _i++) {
         var type = requiredCharacteristics_25[_i];
@@ -1797,14 +1797,14 @@ function MotionSensor(ID, characteristics, isHidden, isPrimary, linkedServices) 
     }
     return service;
 }
-exports.MotionSensor = MotionSensor;
-function OccupancySensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.OccupancySensor = OccupancySensor;
+function Outlet(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000086-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000071-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000047-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000025-0000-1000-8000-0026BB765291', '00000026-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_26 = requiredCharacteristics; _i < requiredCharacteristics_26.length; _i++) {
         var type = requiredCharacteristics_26[_i];
         var OK = false;
@@ -1826,14 +1826,14 @@ function OccupancySensor(ID, characteristics, isHidden, isPrimary, linkedService
     }
     return service;
 }
-exports.OccupancySensor = OccupancySensor;
-function Outlet(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.Outlet = Outlet;
+function SecuritySystem(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000047-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000025-0000-1000-8000-0026BB765291', '00000026-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '0000007E-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000066-0000-1000-8000-0026BB765291', '00000067-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '0000008E-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_27 = requiredCharacteristics; _i < requiredCharacteristics_27.length; _i++) {
         var type = requiredCharacteristics_27[_i];
         var OK = false;
@@ -1855,14 +1855,14 @@ function Outlet(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.Outlet = Outlet;
-function SecuritySystem(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.SecuritySystem = SecuritySystem;
+function ServiceLabel(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '0000007E-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000066-0000-1000-8000-0026BB765291', '00000067-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '0000008E-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '000000CC-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['000000CD-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_28 = requiredCharacteristics; _i < requiredCharacteristics_28.length; _i++) {
         var type = requiredCharacteristics_28[_i];
         var OK = false;
@@ -1884,7 +1884,7 @@ function SecuritySystem(ID, characteristics, isHidden, isPrimary, linkedServices
     }
     return service;
 }
-exports.SecuritySystem = SecuritySystem;
+exports.ServiceLabel = ServiceLabel;
 function Slat(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
@@ -1972,13 +1972,13 @@ function Speaker(ID, characteristics, isHidden, isPrimary, linkedServices) {
     return service;
 }
 exports.Speaker = Speaker;
-function StatefulProgrammableSwitch(ID, characteristics, isHidden, isPrimary, linkedServices) {
+function StatelessProgrammableSwitch(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000088-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000073-0000-1000-8000-0026BB765291', '00000074-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000089-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000073-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291', '000000CB-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_32 = requiredCharacteristics; _i < requiredCharacteristics_32.length; _i++) {
         var type = requiredCharacteristics_32[_i];
         var OK = false;
@@ -2000,13 +2000,13 @@ function StatefulProgrammableSwitch(ID, characteristics, isHidden, isPrimary, li
     }
     return service;
 }
-exports.StatefulProgrammableSwitch = StatefulProgrammableSwitch;
-function StatelessProgrammableSwitch(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.StatelessProgrammableSwitch = StatelessProgrammableSwitch;
+function Switch(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000089-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000073-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '00000049-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000025-0000-1000-8000-0026BB765291'];
     var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_33 = requiredCharacteristics; _i < requiredCharacteristics_33.length; _i++) {
         var type = requiredCharacteristics_33[_i];
@@ -2029,14 +2029,14 @@ function StatelessProgrammableSwitch(ID, characteristics, isHidden, isPrimary, l
     }
     return service;
 }
-exports.StatelessProgrammableSwitch = StatelessProgrammableSwitch;
-function Switch(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.Switch = Switch;
+function TemperatureSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '00000049-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000025-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '0000008A-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['00000011-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_34 = requiredCharacteristics; _i < requiredCharacteristics_34.length; _i++) {
         var type = requiredCharacteristics_34[_i];
         var OK = false;
@@ -2058,14 +2058,14 @@ function Switch(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.Switch = Switch;
-function TemperatureSensor(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.TemperatureSensor = TemperatureSensor;
+function Thermostat(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '0000008A-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['00000011-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '0000004A-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['0000000F-0000-1000-8000-0026BB765291', '00000033-0000-1000-8000-0026BB765291', '00000011-0000-1000-8000-0026BB765291', '00000035-0000-1000-8000-0026BB765291', '00000036-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['00000010-0000-1000-8000-0026BB765291', '00000034-0000-1000-8000-0026BB765291', '0000000D-0000-1000-8000-0026BB765291', '00000012-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_35 = requiredCharacteristics; _i < requiredCharacteristics_35.length; _i++) {
         var type = requiredCharacteristics_35[_i];
         var OK = false;
@@ -2087,14 +2087,14 @@ function TemperatureSensor(ID, characteristics, isHidden, isPrimary, linkedServi
     }
     return service;
 }
-exports.TemperatureSensor = TemperatureSensor;
-function Thermostat(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.Thermostat = Thermostat;
+function Window(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '0000004A-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['0000000F-0000-1000-8000-0026BB765291', '00000033-0000-1000-8000-0026BB765291', '00000011-0000-1000-8000-0026BB765291', '00000035-0000-1000-8000-0026BB765291', '00000036-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['00000010-0000-1000-8000-0026BB765291', '00000034-0000-1000-8000-0026BB765291', '0000000D-0000-1000-8000-0026BB765291', '00000012-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var service = new service_1.default(ID, '0000008B-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var requiredCharacteristics = ['0000006D-0000-1000-8000-0026BB765291', '0000007C-0000-1000-8000-0026BB765291', '00000072-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['0000006F-0000-1000-8000-0026BB765291', '00000024-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_36 = requiredCharacteristics; _i < requiredCharacteristics_36.length; _i++) {
         var type = requiredCharacteristics_36[_i];
         var OK = false;
@@ -2116,14 +2116,14 @@ function Thermostat(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     return service;
 }
-exports.Thermostat = Thermostat;
-function Window(ID, characteristics, isHidden, isPrimary, linkedServices) {
+exports.Window = Window;
+function WindowCovering(ID, characteristics, isHidden, isPrimary, linkedServices) {
     if (isHidden === void 0) { isHidden = false; }
     if (isPrimary === void 0) { isPrimary = false; }
     if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '0000008B-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    var service = new service_1.default(ID, '0000008C-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
     var requiredCharacteristics = ['0000006D-0000-1000-8000-0026BB765291', '0000007C-0000-1000-8000-0026BB765291', '00000072-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['0000006F-0000-1000-8000-0026BB765291', '00000024-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    var optionalCharacteristics = ['0000006F-0000-1000-8000-0026BB765291', '0000007B-0000-1000-8000-0026BB765291', '0000007D-0000-1000-8000-0026BB765291', '0000006C-0000-1000-8000-0026BB765291', '0000006E-0000-1000-8000-0026BB765291', '00000024-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     for (var _i = 0, requiredCharacteristics_37 = requiredCharacteristics; _i < requiredCharacteristics_37.length; _i++) {
         var type = requiredCharacteristics_37[_i];
         var OK = false;
@@ -2139,35 +2139,6 @@ function Window(ID, characteristics, isHidden, isPrimary, linkedServices) {
     }
     for (var _b = 0, characteristics_74 = characteristics; _b < characteristics_74.length; _b++) {
         var characteristic = characteristics_74[_b];
-        if (requiredCharacteristics.indexOf(characteristic.getType()) <= -1 && optionalCharacteristics.indexOf(characteristic.getType()) <= -1)
-            throw new Error(ID + ' can not contain ' + characteristic.getType());
-        service.addCharacteristic(characteristic);
-    }
-    return service;
-}
-exports.Window = Window;
-function WindowCovering(ID, characteristics, isHidden, isPrimary, linkedServices) {
-    if (isHidden === void 0) { isHidden = false; }
-    if (isPrimary === void 0) { isPrimary = false; }
-    if (linkedServices === void 0) { linkedServices = []; }
-    var service = new service_1.default(ID, '0000008C-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    var requiredCharacteristics = ['0000006D-0000-1000-8000-0026BB765291', '0000007C-0000-1000-8000-0026BB765291', '00000072-0000-1000-8000-0026BB765291'];
-    var optionalCharacteristics = ['0000006F-0000-1000-8000-0026BB765291', '0000007B-0000-1000-8000-0026BB765291', '0000007D-0000-1000-8000-0026BB765291', '0000006C-0000-1000-8000-0026BB765291', '0000006E-0000-1000-8000-0026BB765291', '00000024-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
-    for (var _i = 0, requiredCharacteristics_38 = requiredCharacteristics; _i < requiredCharacteristics_38.length; _i++) {
-        var type = requiredCharacteristics_38[_i];
-        var OK = false;
-        for (var _a = 0, characteristics_75 = characteristics; _a < characteristics_75.length; _a++) {
-            var characteristic = characteristics_75[_a];
-            if (characteristic.getType() == type) {
-                OK = true;
-                break;
-            }
-        }
-        if (!OK)
-            throw new Error(type + 'is required for this service: ' + ID);
-    }
-    for (var _b = 0, characteristics_76 = characteristics; _b < characteristics_76.length; _b++) {
-        var characteristic = characteristics_76[_b];
         if (requiredCharacteristics.indexOf(characteristic.getType()) <= -1 && optionalCharacteristics.indexOf(characteristic.getType()) <= -1)
             throw new Error(ID + ' can not contain ' + characteristic.getType());
         service.addCharacteristic(characteristic);

--- a/node_modules/has-node/src/predefinedTypes/predefined.ts
+++ b/node_modules/has-node/src/predefinedTypes/predefined.ts
@@ -13,7 +13,7 @@ import Service from '../service';
 //Characteristics
 
 export function AccessoryFlags(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '000000A6-0000-1000-8000-0026BB765291', 'uint32', false, true, true, true, false, undefined, "Accessory Flags", undefined, undefined, undefined, undefined, [0], undefined);
+    let characteristic = new Characteristic(ID, '000000A6-0000-1000-8000-0026BB765291', 'uint32', false, true, true, true, false, undefined, "Accessory Flags", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -66,15 +66,6 @@ export function AirQuality(ID: number, value: any, onWrite?: OnWrite): Character
     return characteristic;
 }
 
-export function AppMatchingIdentifier(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '000000A4-0000-1000-8000-0026BB765291', 'tlv8', false, false, true, true, false, undefined, "App Matching Identifier", undefined, undefined, undefined, undefined, undefined, undefined);
-    if (value != null && value != undefined)
-        characteristic.setValue(value);
-    if (onWrite)
-        characteristic.onWrite = onWrite;
-    return characteristic;
-}
-
 export function AudioFeedback(ID: number, value: any, onWrite?: OnWrite): Characteristic {
     let characteristic = new Characteristic(ID, '00000005-0000-1000-8000-0026BB765291', 'bool', false, true, true, false, false, undefined, "Audio Feedback", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
@@ -112,7 +103,7 @@ export function CarbonDioxideDetected(ID: number, value: any, onWrite?: OnWrite)
 }
 
 export function CarbonDioxideLevel(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000093-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Dioxide Level", 0, 100000, 100, undefined, undefined, undefined);
+    let characteristic = new Characteristic(ID, '00000093-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Dioxide Level", 0, 100000, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -121,7 +112,7 @@ export function CarbonDioxideLevel(ID: number, value: any, onWrite?: OnWrite): C
 }
 
 export function CarbonDioxidePeakLevel(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000094-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Dioxide Peak Level", 0, 100000, 100, undefined, undefined, undefined);
+    let characteristic = new Characteristic(ID, '00000094-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Dioxide Peak Level", 0, 100000, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -139,7 +130,7 @@ export function CarbonMonoxideDetected(ID: number, value: any, onWrite?: OnWrite
 }
 
 export function CarbonMonoxideLevel(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000090-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Monoxide Level", 0, 100, 0.1, undefined, undefined, undefined);
+    let characteristic = new Characteristic(ID, '00000090-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Monoxide Level", 0, 100, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -148,7 +139,7 @@ export function CarbonMonoxideLevel(ID: number, value: any, onWrite?: OnWrite): 
 }
 
 export function CarbonMonoxidePeakLevel(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000091-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Monoxide Peak Level", 0, 100, 0.1, undefined, undefined, undefined);
+    let characteristic = new Characteristic(ID, '00000091-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, undefined, "Carbon Monoxide Peak Level", 0, 100, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -158,6 +149,15 @@ export function CarbonMonoxidePeakLevel(ID: number, value: any, onWrite?: OnWrit
 
 export function ChargingState(ID: number, value: any, onWrite?: OnWrite): Characteristic {
     let characteristic = new Characteristic(ID, '0000008F-0000-1000-8000-0026BB765291', 'uint8', false, true, true, true, false, undefined, "Charging State", undefined, undefined, undefined, undefined, [0, 1, 2], undefined);
+    if (value != null && value != undefined)
+        characteristic.setValue(value);
+    if (onWrite)
+        characteristic.onWrite = onWrite;
+    return characteristic;
+}
+
+export function ColorTemperature(ID: number, value: any, onWrite?: OnWrite): Characteristic {
+    let characteristic = new Characteristic(ID, '000000CE-0000-1000-8000-0026BB765291', 'uint32', false, true, true, false, false, undefined, "Color Temperature", 140, 500, 1, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -193,7 +193,7 @@ export function CurrentAirPurifierState(ID: number, value: any, onWrite?: OnWrit
 }
 
 export function CurrentAmbientLightLevel(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '0000006B-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, "lux", "Current Ambient Light Level", 0.0001, 100000, 0.0001, undefined, undefined, undefined);
+    let characteristic = new Characteristic(ID, '0000006B-0000-1000-8000-0026BB765291', 'float', false, true, true, true, false, "lux", "Current Ambient Light Level", 0.0001, 100000, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -445,7 +445,7 @@ export function LockLastKnownAction(ID: number, value: any, onWrite?: OnWrite): 
 }
 
 export function LockManagementAutoSecurityTimeout(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '0000001A-0000-1000-8000-0026BB765291', 'uint32', false, true, true, false, false, "seconds", "Lock Management Auto Security Timeout", 0, 86400, 1, undefined, undefined, undefined);
+    let characteristic = new Characteristic(ID, '0000001A-0000-1000-8000-0026BB765291', 'uint32', false, true, true, false, false, "seconds", "Lock Management Auto Security Timeout", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -498,8 +498,8 @@ export function Model(ID: number, value: any, onWrite?: OnWrite): Characteristic
     return characteristic;
 }
 
-export function Mute(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '0000011A-0000-1000-8000-0026BB765291', 'bool', false, true, true, false, false, undefined, "Mute", undefined, undefined, undefined, undefined, undefined, undefined);
+export function MotionDetected(ID: number, value: any, onWrite?: OnWrite): Characteristic {
+    let characteristic = new Characteristic(ID, '00000022-0000-1000-8000-0026BB765291', 'bool', false, true, true, true, false, undefined, "Motion Detected", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -507,8 +507,8 @@ export function Mute(ID: number, value: any, onWrite?: OnWrite): Characteristic 
     return characteristic;
 }
 
-export function MotionDetected(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000022-0000-1000-8000-0026BB765291', 'bool', false, true, true, true, false, undefined, "Motion Detected", undefined, undefined, undefined, undefined, undefined, undefined);
+export function Mute(ID: number, value: any, onWrite?: OnWrite): Characteristic {
+    let characteristic = new Characteristic(ID, '0000011A-0000-1000-8000-0026BB765291', 'bool', false, true, true, false, false, undefined, "Mute", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -661,16 +661,7 @@ export function PositionState(ID: number, value: any, onWrite?: OnWrite): Charac
 }
 
 export function ProgrammableSwitchEvent(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000073-0000-1000-8000-0026BB765291', 'uint8', false, true, true, true, false, undefined, "Programmable Switch Event", 0, 1, 1, undefined, undefined, undefined);
-    if (value != null && value != undefined)
-        characteristic.setValue(value);
-    if (onWrite)
-        characteristic.onWrite = onWrite;
-    return characteristic;
-}
-
-export function ProgrammableSwitchOutputState(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000074-0000-1000-8000-0026BB765291', 'uint8', false, true, true, false, false, undefined, "Programmable Switch Output State", 0, 1, 1, undefined, undefined, undefined);
+    let characteristic = new Characteristic(ID, '00000073-0000-1000-8000-0026BB765291', 'uint8', false, true, true, true, false, undefined, "Programmable Switch Event", undefined, undefined, undefined, undefined, [0, 1, 2], undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -759,8 +750,8 @@ export function SecuritySystemTargetState(ID: number, value: any, onWrite?: OnWr
     return characteristic;
 }
 
-export function SelectedStreamConfiguration(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000117-0000-1000-8000-0026BB765291', 'tlv8', false, false, true, false, false, undefined, "Selected Stream Configuration", undefined, undefined, undefined, undefined, undefined, undefined);
+export function SelectedRTPStreamConfiguration(ID: number, value: any, onWrite?: OnWrite): Characteristic {
+    let characteristic = new Characteristic(ID, '00000117-0000-1000-8000-0026BB765291', 'tlv8', false, false, true, false, false, undefined, "Selected RTP Stream Configuration", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -777,8 +768,26 @@ export function SerialNumber(ID: number, value: any, onWrite?: OnWrite): Charact
     return characteristic;
 }
 
+export function ServiceLabelIndex(ID: number, value: any, onWrite?: OnWrite): Characteristic {
+    let characteristic = new Characteristic(ID, '000000CB-0000-1000-8000-0026BB765291', 'uint8', false, false, true, true, false, undefined, "Service Label Index", 1, 255, 1, undefined, undefined, undefined);
+    if (value != null && value != undefined)
+        characteristic.setValue(value);
+    if (onWrite)
+        characteristic.onWrite = onWrite;
+    return characteristic;
+}
+
+export function ServiceLabelNamespace(ID: number, value: any, onWrite?: OnWrite): Characteristic {
+    let characteristic = new Characteristic(ID, '000000CD-0000-1000-8000-0026BB765291', 'uint8', false, false, true, true, false, undefined, "Service Label Namespace", undefined, undefined, undefined, undefined, [0, 1], undefined);
+    if (value != null && value != undefined)
+        characteristic.setValue(value);
+    if (onWrite)
+        characteristic.onWrite = onWrite;
+    return characteristic;
+}
+
 export function SetupEndpoints(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000118-0000-1000-8000-0026BB765291', 'tlv8', false, true, true, false, false, undefined, "Setup Endpoints", undefined, undefined, undefined, undefined, undefined, undefined);
+    let characteristic = new Characteristic(ID, '00000118-0000-1000-8000-0026BB765291', 'tlv8', false, false, true, false, false, undefined, "Setup Endpoints", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -787,7 +796,7 @@ export function SetupEndpoints(ID: number, value: any, onWrite?: OnWrite): Chara
 }
 
 export function SlatType(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '000000C0-0000-1000-8000-0026BB765291', 'uint8', false, true, true, true, false, undefined, "Slat Type", undefined, undefined, undefined, undefined, [0, 1], undefined);
+    let characteristic = new Characteristic(ID, '000000C0-0000-1000-8000-0026BB765291', 'uint8', false, false, true, true, false, undefined, "Slat Type", undefined, undefined, undefined, undefined, [0, 1], undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -797,15 +806,6 @@ export function SlatType(ID: number, value: any, onWrite?: OnWrite): Characteris
 
 export function SmokeDetected(ID: number, value: any, onWrite?: OnWrite): Characteristic {
     let characteristic = new Characteristic(ID, '00000076-0000-1000-8000-0026BB765291', 'uint8', false, true, true, true, false, undefined, "Smoke Detected", undefined, undefined, undefined, undefined, [0, 1], undefined);
-    if (value != null && value != undefined)
-        characteristic.setValue(value);
-    if (onWrite)
-        characteristic.onWrite = onWrite;
-    return characteristic;
-}
-
-export function SoftwareRevision(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000054-0000-1000-8000-0026BB765291', 'string', false, false, true, true, false, undefined, "Software Revision", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -859,7 +859,7 @@ export function StatusTampered(ID: number, value: any, onWrite?: OnWrite): Chara
 }
 
 export function StreamingStatus(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000120-0000-1000-8000-0026BB765291', 'tlv8', false, true, true, false, false, undefined, "Streaming Status", undefined, undefined, undefined, undefined, undefined, undefined);
+    let characteristic = new Characteristic(ID, '00000120-0000-1000-8000-0026BB765291', 'tlv8', false, true, true, true, false, undefined, "Streaming Status", undefined, undefined, undefined, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -1066,7 +1066,7 @@ export function VOCDensity(ID: number, value: any, onWrite?: OnWrite): Character
 }
 
 export function Volume(ID: number, value: any, onWrite?: OnWrite): Characteristic {
-    let characteristic = new Characteristic(ID, '00000119-0000-1000-8000-0026BB765291', 'float', false, true, true, false, false, "percentage", "Volume", 0, 100, 1, undefined, undefined, undefined);
+    let characteristic = new Characteristic(ID, '00000119-0000-1000-8000-0026BB765291', 'uint8', false, true, true, false, false, "percentage", "Volume", 0, 100, 1, undefined, undefined, undefined);
     if (value != null && value != undefined)
         characteristic.setValue(value);
     if (onWrite)
@@ -1090,8 +1090,8 @@ export function WaterLevel(ID: number, value: any, onWrite?: OnWrite): Character
 export function AccessoryInformation(ID: number, characteristics: Characteristic[], isHidden: boolean = false, isPrimary: boolean = false, linkedServices: number[] = []): Service {
     let service = new Service(ID, '0000003E-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
     
-    let requiredCharacteristics = ['00000014-0000-1000-8000-0026BB765291', '00000020-0000-1000-8000-0026BB765291', '00000021-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '00000030-0000-1000-8000-0026BB765291'];
-    let optionalCharacteristics = ['00000052-0000-1000-8000-0026BB765291', '00000053-0000-1000-8000-0026BB765291', '00000054-0000-1000-8000-0026BB765291', '000000A6-0000-1000-8000-0026BB765291', '000000A4-0000-1000-8000-0026BB765291'];
+    let requiredCharacteristics = ['00000014-0000-1000-8000-0026BB765291', '00000020-0000-1000-8000-0026BB765291', '00000021-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '00000030-0000-1000-8000-0026BB765291', '00000052-0000-1000-8000-0026BB765291'];
+    let optionalCharacteristics = ['00000053-0000-1000-8000-0026BB765291', '000000A6-0000-1000-8000-0026BB765291'];
     
     for (let type of requiredCharacteristics) {
         let OK = false;
@@ -1182,36 +1182,6 @@ export function BatteryService(ID: number, characteristics: Characteristic[], is
     
     let requiredCharacteristics = ['00000068-0000-1000-8000-0026BB765291', '0000008F-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291'];
     let optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
-    
-    for (let type of requiredCharacteristics) {
-        let OK = false;
-        
-        for (let characteristic of characteristics) {
-            if (characteristic.getType() == type) {
-                OK = true;
-                break;
-            }
-        }
-        
-        if (!OK)
-            throw new Error(type + 'is required for this service: ' + ID);
-    }
-    
-    for (let characteristic of characteristics) {
-        if (requiredCharacteristics.indexOf(characteristic.getType()) <= -1 && optionalCharacteristics.indexOf(characteristic.getType()) <= -1)
-            throw new Error(ID + ' can not contain ' + characteristic.getType());
-            
-        service.addCharacteristic(characteristic);
-    }
-    
-    return service;
-}
-
-export function CameraControl(ID: number, characteristics: Characteristic[], isHidden: boolean = false, isPrimary: boolean = false, linkedServices: number[] = []): Service {
-    let service = new Service(ID, '00000111-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    
-    let requiredCharacteristics = ['00000025-0000-1000-8000-0026BB765291'];
-    let optionalCharacteristics = ['0000006C-0000-1000-8000-0026BB765291', '0000006E-0000-1000-8000-0026BB765291', '0000007B-0000-1000-8000-0026BB765291', '0000007D-0000-1000-8000-0026BB765291', '0000011B-0000-1000-8000-0026BB765291', '0000011C-0000-1000-8000-0026BB765291', '0000011D-0000-1000-8000-0026BB765291', '0000011E-0000-1000-8000-0026BB765291', '0000011F-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
     
     for (let type of requiredCharacteristics) {
         let OK = false;
@@ -1661,7 +1631,7 @@ export function LightSensor(ID: number, characteristics: Characteristic[], isHid
     let service = new Service(ID, '00000084-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
     
     let requiredCharacteristics = ['0000006B-0000-1000-8000-0026BB765291'];
-    let optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291'];
+    let optionalCharacteristics = ['00000075-0000-1000-8000-0026BB765291', '00000077-0000-1000-8000-0026BB765291', '0000007A-0000-1000-8000-0026BB765291', '00000079-0000-1000-8000-0026BB765291', '00000023-0000-1000-8000-0026BB765291', '000000CE-0000-1000-8000-0026BB765291'];
     
     for (let type of requiredCharacteristics) {
         let OK = false;
@@ -1927,6 +1897,36 @@ export function SecuritySystem(ID: number, characteristics: Characteristic[], is
     return service;
 }
 
+export function ServiceLabel(ID: number, characteristics: Characteristic[], isHidden: boolean = false, isPrimary: boolean = false, linkedServices: number[] = []): Service {
+    let service = new Service(ID, '000000CC-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
+    
+    let requiredCharacteristics = ['000000CD-0000-1000-8000-0026BB765291'];
+    let optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
+    
+    for (let type of requiredCharacteristics) {
+        let OK = false;
+        
+        for (let characteristic of characteristics) {
+            if (characteristic.getType() == type) {
+                OK = true;
+                break;
+            }
+        }
+        
+        if (!OK)
+            throw new Error(type + 'is required for this service: ' + ID);
+    }
+    
+    for (let characteristic of characteristics) {
+        if (requiredCharacteristics.indexOf(characteristic.getType()) <= -1 && optionalCharacteristics.indexOf(characteristic.getType()) <= -1)
+            throw new Error(ID + ' can not contain ' + characteristic.getType());
+            
+        service.addCharacteristic(characteristic);
+    }
+    
+    return service;
+}
+
 export function Slat(ID: number, characteristics: Characteristic[], isHidden: boolean = false, isPrimary: boolean = false, linkedServices: number[] = []): Service {
     let service = new Service(ID, '000000B9-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
     
@@ -2017,41 +2017,11 @@ export function Speaker(ID: number, characteristics: Characteristic[], isHidden:
     return service;
 }
 
-export function StatefulProgrammableSwitch(ID: number, characteristics: Characteristic[], isHidden: boolean = false, isPrimary: boolean = false, linkedServices: number[] = []): Service {
-    let service = new Service(ID, '00000088-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
-    
-    let requiredCharacteristics = ['00000073-0000-1000-8000-0026BB765291', '00000074-0000-1000-8000-0026BB765291'];
-    let optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
-    
-    for (let type of requiredCharacteristics) {
-        let OK = false;
-        
-        for (let characteristic of characteristics) {
-            if (characteristic.getType() == type) {
-                OK = true;
-                break;
-            }
-        }
-        
-        if (!OK)
-            throw new Error(type + 'is required for this service: ' + ID);
-    }
-    
-    for (let characteristic of characteristics) {
-        if (requiredCharacteristics.indexOf(characteristic.getType()) <= -1 && optionalCharacteristics.indexOf(characteristic.getType()) <= -1)
-            throw new Error(ID + ' can not contain ' + characteristic.getType());
-            
-        service.addCharacteristic(characteristic);
-    }
-    
-    return service;
-}
-
 export function StatelessProgrammableSwitch(ID: number, characteristics: Characteristic[], isHidden: boolean = false, isPrimary: boolean = false, linkedServices: number[] = []): Service {
     let service = new Service(ID, '00000089-0000-1000-8000-0026BB765291', isHidden, isPrimary, linkedServices);
     
     let requiredCharacteristics = ['00000073-0000-1000-8000-0026BB765291'];
-    let optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291'];
+    let optionalCharacteristics = ['00000023-0000-1000-8000-0026BB765291', '000000CB-0000-1000-8000-0026BB765291'];
     
     for (let type of requiredCharacteristics) {
         let OK = false;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "author": "Bas Jansen",
   "license": "ISC",
   "dependencies": {
-    "has-node": "github:abedinpour/HAS"
+    "has-node": "github:RobinBol/HAS"
   }
 }


### PR DESCRIPTION
I've updated the predefinedTypes to enable ColorTemperature for light_temperature, currently it is using Saturation for that. I only replaced the predefinedTypes directory with the updated version, since the module has native bindings which can not be build on my Mac. So accepting this PR works, but best is to wait for this PR (https://github.com/abedinpour/HAS/pull/4) to be merged and then build the has-node library again and update it in com.swttt.homekit (or update has-node based on my fork: https://github.com/RobinBol/HAS).

Next to that I fixed that ColorTemperature characteristic works together with Saturation and Hue. I also added a virtual light_saturation capability for lights that have RGB control.

PS. this is a personal PR nothing to do with Athom. I am using HomeyKit myself and lacked the ability to control the light temperature of my Milight LED strips.