### PR TITLE
Air pressure

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,7 @@
 // process.env.DEBUG = '*';
 
 const Homey = require('homey')
-const {
-  HomeyAPI
-} = require('athom-api')
+const { HomeyAPI } = require('athom-api')
 const fs = require('fs');
 const storage = require('node-persist');
 const path = require('path');

--- a/app.js
+++ b/app.js
@@ -166,8 +166,8 @@ class HomekitApp extends Homey.App {
       isPaired = true;
       bridge.addBridgedAccessory(homekit.createSecuritySystem(device, api));
     }
-    else if ([ 'sensor', 'other' ].includes(device.class) && ('measure_luminance' in capabilities || 'measure_temperature' in capabilities || 'measure_humidity' in capabilities || 'alarm_motion' in capabilities || 'alarm_water' in capabilities || 'alarm_contact' in capabilities || 'alarm_smoke' in capabilities || 'alarm_co' in capabilities || 'alarm_co2' in capabilities)) {
-      console.log('Found Sensor: ' + device.name)
+    else if ([ 'sensor', 'other' ].includes(device.class) && ('measure_luminance' in capabilities || 'measure_temperature' in capabilities || 'measure_humidity' in capabilities || 'measure_pressure' in capabilities || 'alarm_motion' in capabilities || 'alarm_water' in capabilities || 'alarm_contact' in capabilities || 'alarm_smoke' in capabilities || 'alarm_co' in capabilities || 'alarm_co2' in capabilities)) {
+      console.log('Found Sensor: ', device.name, ', caps = ', capabilities);
       isPaired = true;
       bridge.addBridgedAccessory(homekit.createSensor(device, api, capabilities));
     }

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.swttt.homekit",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "sdk": 2,
   "permissions": [
     "homey:manager:api"

--- a/lib/custom-characteristics.js
+++ b/lib/custom-characteristics.js
@@ -1,0 +1,20 @@
+const Characteristic = require('hap-nodejs').Characteristic;
+
+module.exports.AirPressure = class AirPressure extends Characteristic {
+
+  constructor() {
+    super('Air Pressure', AirPressure.UUID);
+    this.setProps({
+      format:   Characteristic.Formats.UINT16,
+      unit:     'mbar',
+      minValue: 700,
+      maxValue: 1200,
+      minStep:  1,
+      perms:    [ Characteristic.Perms.READ, Characteristic.Perms.NOTIFY ]
+    });
+    this.value = this.getDefaultValue();
+  }
+
+};
+
+module.exports.AirPressure.UUID = 'E863F10F-079E-48FF-8F27-9C2605A29F52';

--- a/lib/custom-services.js
+++ b/lib/custom-services.js
@@ -1,0 +1,13 @@
+const Service = require('hap-nodejs').Service;
+const { AirPressure } = require('./custom-characteristics'); 
+
+module.exports.AirPressureSensor = class AirPressureSensor extends Service {
+
+  constructor(displayName, subtype) {
+    super(displayName, AirPressureSensor.UUID, subtype);
+    this.addCharacteristic(AirPressure);
+  }
+
+};
+
+module.exports.AirPressureSensor.UUID = 'E863F00A-079E-48FF-8F27-9C2605A29F52';

--- a/lib/devices/light.js
+++ b/lib/devices/light.js
@@ -74,13 +74,13 @@ module.exports = function(device, api) {
       .addCharacteristic(Characteristic.ColorTemperature)
       .on('set', function(value, callback) {
 
-		// If device uses light_mode and was previously set on not temperature
-	    // wait for color mode to be adjusted before setting light_temperature
-		if ('light_mode' in device.capabilities && device.state.light_mode !== 'temperature') {
-		  device.setCapabilityValue("light_mode", "temperature");
-	    }
+    // If device uses light_mode and was previously set on not temperature
+      // wait for color mode to be adjusted before setting light_temperature
+    if ('light_mode' in device.capabilities && device.state.light_mode !== 'temperature') {
+      device.setCapabilityValue("light_mode", "temperature");
+      }
 
-		device.setCapabilityValue("light_temperature", map(140, 500, 0, 1, value))
+    device.setCapabilityValue("light_temperature", map(140, 500, 0, 1, value))
         callback();
       })
       .on('get', function(callback) {
@@ -124,11 +124,11 @@ module.exports = function(device, api) {
         .getCharacteristic(Characteristic.Saturation)
         .updateValue(state.light_saturation * 100);
     }
-	if (state.light_temperature) {
-      homekitAccessory
-        .getService(Service.Lightbulb)
-        .getCharacteristic(Characteristic.ColorTemperature)
-        .updateValue(map(0, 1, 140, 500, state.light_temperature));
+    if (state.light_temperature) {
+        homekitAccessory
+          .getService(Service.Lightbulb)
+          .getCharacteristic(Characteristic.ColorTemperature)
+          .updateValue(map(0, 1, 140, 500, state.light_temperature));
     }
     if (state.light_hue) {
       homekitAccessory

--- a/lib/devices/securitysystem.js
+++ b/lib/devices/securitysystem.js
@@ -5,57 +5,39 @@ const uuid = require('hap-nodejs').uuid;
 const debounce = require('lodash.debounce');
 
 function state2value(state, targetStateValue) {
-  if (state == 'partially_armed')
-  {
-	if (targetStateValue == 0){
-	  return 0;	
-	}
-    else if (targetStateValue == 2){
-	  return 2;	
-	}
-	else{
-	  return 0
-	}	
-  }
-  else if (state == 'armed')
-  {
+  if (state == 'partially_armed') {
+    if (targetStateValue == 0) {
+      return 0;
+    } else if (targetStateValue == 2) {
+      return 2;
+    } else {
+      return 0
+    }
+  } else if (state == 'armed') {
     return 1;
-  }
-  else if (state == 'disarmed')
-  {
+  } else if (state == 'disarmed') {
     return 3;
-  }
-  else
-  {
-    return 3;	
+  } else {
+    return 3;
   }
 }
 
 function value2state(value) {
-  if (value == 0)
-  {
-    return 'partially_armed'
-  }
-  else if (value == 1)
-  {
-    return 'armed';
-  }
-  else if (value == 2)
-  {
+  if (value == 0) {
     return 'partially_armed';
-  }
-  else if (value == 3)
-  {
+  } else if (value == 1) {
+    return 'armed';
+  } else if (value == 2) {
+    return 'partially_armed';
+  } else if (value == 3) {
     return 'disarmed';
-  }
-  else
-  {
-    return 'disarmed';	
+  } else {
+    return 'disarmed';
   }
 }
 
 module.exports = function(device, api) {
-	
+
   // Var that keeps the target state
   var targetStateValue = null;
 
@@ -82,12 +64,12 @@ module.exports = function(device, api) {
     .getCharacteristic(Characteristic.SecuritySystemCurrentState)
     .on('get', function(callback) {
       //support for Heimdall app alarm capability
-	  if('alarm_heimdall' in device.capabilities && device.state.alarm_heimdall === true){
-	    callback(null, 4);    
-	  }
-	  else{
-	    callback(null, state2value(device.state.homealarm_state, targetStateValue));	
-	  }     
+    if('alarm_heimdall' in device.capabilities && device.state.alarm_heimdall === true){
+      callback(null, 4);
+    }
+    else{
+      callback(null, state2value(device.state.homealarm_state, targetStateValue));
+    }
     });
 
   // Target state
@@ -95,7 +77,7 @@ module.exports = function(device, api) {
     .getService(Service.SecuritySystem)
     .getCharacteristic(Characteristic.SecuritySystemTargetState)
     .on('set', function(value, callback) {
-	  targetStateValue = value;
+    targetStateValue = value;
       device.setCapabilityValue("homealarm_state", value2state(value) )
       callback();
     })
@@ -118,26 +100,26 @@ module.exports = function(device, api) {
 
     console.log('Realtime update from: ' + device.name)
 
-	//support for Heimdall app alarm capability
-	if('alarm_heimdall' in device.capabilities && state.alarm_heimdall === true){
+    //support for Heimdall app alarm capability
+    if('alarm_heimdall' in device.capabilities && state.alarm_heimdall === true){
+        homekitAccessory
+          .getService(Service.SecuritySystem)
+          .getCharacteristic(Characteristic.SecuritySystemCurrentState)
+          .updateValue(4);
+    }
+    else
+    {
+        homekitAccessory
+        .getService(Service.SecuritySystem)
+        .getCharacteristic(Characteristic.SecuritySystemTargetState)
+        .updateValue(state2value(state.homealarm_state, targetStateValue));
+
       homekitAccessory
         .getService(Service.SecuritySystem)
         .getCharacteristic(Characteristic.SecuritySystemCurrentState)
-        .updateValue(4);
-	}
-	else
-	{		
-      homekitAccessory
-	    .getService(Service.SecuritySystem)
-	    .getCharacteristic(Characteristic.SecuritySystemTargetState)
-	    .updateValue(state2value(state.homealarm_state, targetStateValue));
-	
-	  homekitAccessory
-	    .getService(Service.SecuritySystem)
-	    .getCharacteristic(Characteristic.SecuritySystemCurrentState)
-	    .updateValue(state2value(state.homealarm_state, targetStateValue));
-	}
-	
+        .updateValue(state2value(state.homealarm_state, targetStateValue));
+    }
+
     if('alarm_tamper' in device.capabilities){
       homekitAccessory
         .getService(Service.SecuritySystem)

--- a/lib/devices/sensor.js
+++ b/lib/devices/sensor.js
@@ -1,8 +1,10 @@
-const Accessory = require('hap-nodejs').Accessory;
-const Service = require('hap-nodejs').Service;
-const Characteristic = require('hap-nodejs').Characteristic;
-const uuid = require('hap-nodejs').uuid;
-const debounce = require('lodash.debounce');
+const Accessory             = require('hap-nodejs').Accessory;
+const Service               = require('hap-nodejs').Service;
+const Characteristic        = require('hap-nodejs').Characteristic;
+const uuid                  = require('hap-nodejs').uuid;
+const debounce              = require('lodash.debounce');
+const CustomServices        = require('../custom-services');
+const CustomCharacteristics = require('../custom-characteristics');
 
 module.exports = function(device, api, capabilities) {
   let stateKeys  = Object.keys(device.state);
@@ -57,6 +59,16 @@ module.exports = function(device, api, capabilities) {
 	    .getCharacteristic(Characteristic.CurrentRelativeHumidity)
 	    .on('get', function(callback) {
 	      callback(null, capValue('measure_humidity'));
+	    });
+  }
+
+  // Air Pressure Sensor
+  if ('measure_pressure' in capabilities) {
+	  homekitAccessory
+	    .addService(CustomServices.AirPressureSensor, device.name)
+	    .getCharacteristic(CustomCharacteristics.AirPressure)
+	    .on('get', function(callback) {
+	      callback(null, capValue('measure_pressure'));
 	    });
   }
 
@@ -169,10 +181,18 @@ module.exports = function(device, api, capabilities) {
     // Humidity Sensor
     if('measure_humidity' in capabilities){
       homekitAccessory
-          .getService(Service.HumiditySensor)
-          .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-          .updateValue(capValue('measure_humidity'));
-      }
+      .getService(Service.HumiditySensor)
+      .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+      .updateValue(capValue('measure_humidity'));
+    }
+
+    // Air Pressure Sensor
+    if ('measure_pressure' in capabilities) {
+      homekitAccessory
+      .getService(CustomServices.AirPressureSensor)
+      .getCharacteristic(CustomCharacteristics.AirPressure)
+      .updateValue(capValue('measure_pressure'));
+    }
 
     // Motion Sensor
     if('alarm_motion' in capabilities){

--- a/lib/devices/sensor.js
+++ b/lib/devices/sensor.js
@@ -40,119 +40,119 @@ module.exports = function(device, api, capabilities) {
 
   // Temperature Sensor
   if('measure_temperature' in capabilities){
-	  homekitAccessory
-	    .addService(Service.TemperatureSensor, device.name)
-	    .getCharacteristic(Characteristic.CurrentTemperature)
+    homekitAccessory
+      .addService(Service.TemperatureSensor, device.name)
+      .getCharacteristic(Characteristic.CurrentTemperature)
       .setProps({
         minValue : -100,
         maxValue : 100
       })
-	    .on('get', function(callback) {
-	      callback(null, capValue('measure_temperature'));
-	    });
+      .on('get', function(callback) {
+        callback(null, capValue('measure_temperature'));
+      });
   }
 
   // Humidity Sensor
   if('measure_humidity' in capabilities){
-	  homekitAccessory
-	    .addService(Service.HumiditySensor, device.name)
-	    .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-	    .on('get', function(callback) {
-	      callback(null, capValue('measure_humidity'));
-	    });
+    homekitAccessory
+      .addService(Service.HumiditySensor, device.name)
+      .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+      .on('get', function(callback) {
+        callback(null, capValue('measure_humidity'));
+      });
   }
 
   // Air Pressure Sensor
   if ('measure_pressure' in capabilities) {
-	  homekitAccessory
-	    .addService(CustomServices.AirPressureSensor, device.name)
-	    .getCharacteristic(CustomCharacteristics.AirPressure)
-	    .on('get', function(callback) {
-	      callback(null, capValue('measure_pressure'));
-	    });
+    homekitAccessory
+      .addService(CustomServices.AirPressureSensor, device.name)
+      .getCharacteristic(CustomCharacteristics.AirPressure)
+      .on('get', function(callback) {
+        callback(null, capValue('measure_pressure'));
+      });
   }
 
   // Motion Sensor
   if('alarm_motion' in capabilities){
-	  homekitAccessory
-	    .addService(Service.MotionSensor, device.name)
-	    .getCharacteristic(Characteristic.MotionDetected)
-	    .on('get', function(callback) {
-	      callback(null, ~~capValue('alarm_motion'));
-	    });
+    homekitAccessory
+      .addService(Service.MotionSensor, device.name)
+      .getCharacteristic(Characteristic.MotionDetected)
+      .on('get', function(callback) {
+        callback(null, ~~capValue('alarm_motion'));
+      });
   }
 
   // Leak Sensor
   if('alarm_water' in capabilities){
-  	  homekitAccessory
-	    .addService(Service.LeakSensor, device.name)
-	    .getCharacteristic(Characteristic.LeakDetected)
-	    .on('get', function(callback) {
-	      callback(null, ~~capValue('alarm_water'));
-	    });
+      homekitAccessory
+      .addService(Service.LeakSensor, device.name)
+      .getCharacteristic(Characteristic.LeakDetected)
+      .on('get', function(callback) {
+        callback(null, ~~capValue('alarm_water'));
+      });
   }
 
   // Contact Sensor
   if('alarm_contact' in capabilities){
-  	  homekitAccessory
-	    .addService(Service.ContactSensor, device.name)
-	    .getCharacteristic(Characteristic.ContactSensorState)
-	    .on('get', function(callback) {
-	      callback(null, ~~capValue('alarm_contact'));
-	    });
+      homekitAccessory
+      .addService(Service.ContactSensor, device.name)
+      .getCharacteristic(Characteristic.ContactSensorState)
+      .on('get', function(callback) {
+        callback(null, ~~capValue('alarm_contact'));
+      });
   }
-  
+
   // Smoke Sensor
   if('alarm_smoke' in capabilities){
-	  // Smoke Detected
-	  homekitAccessory
-	    .addService(Service.SmokeSensor, device.name)
-	    .getCharacteristic(Characteristic.SmokeDetected)
-	    .on('get', function(callback) {
-	      callback(null, ~~capValue('alarm_smoke'));
-	    });
+    // Smoke Detected
+    homekitAccessory
+      .addService(Service.SmokeSensor, device.name)
+      .getCharacteristic(Characteristic.SmokeDetected)
+      .on('get', function(callback) {
+        callback(null, ~~capValue('alarm_smoke'));
+      });
   }
 
   // CarbonMonoxide Sensor
   if('alarm_co' in capabilities){
-	  // CarbonMonoxideDetected
-	  homekitAccessory
-	    .addService(Service.CarbonMonoxideSensor, device.name)
-	    .getCharacteristic(Characteristic.CarbonMonoxideDetected)
-	    .on('get', function(callback) {
-	      callback(null, ~~capValue('alarm_co'));
-	    });
+    // CarbonMonoxideDetected
+    homekitAccessory
+      .addService(Service.CarbonMonoxideSensor, device.name)
+      .getCharacteristic(Characteristic.CarbonMonoxideDetected)
+      .on('get', function(callback) {
+        callback(null, ~~capValue('alarm_co'));
+      });
 
-	  // CarbonMonoxideLevel
-	  if('measure_co' in capabilities){
-	  homekitAccessory
-	    .getService(Service.CarbonMonoxideSensor)
-	    .getCharacteristic(Characteristic.CarbonMonoxideLevel)
-	    .on('get', function(callback) {
-	      callback(null, capValue('measure_co'));
-	    });
-	  }
+    // CarbonMonoxideLevel
+    if('measure_co' in capabilities){
+    homekitAccessory
+      .getService(Service.CarbonMonoxideSensor)
+      .getCharacteristic(Characteristic.CarbonMonoxideLevel)
+      .on('get', function(callback) {
+        callback(null, capValue('measure_co'));
+      });
+    }
   }
 
   // CarbonDioxide Sensor
   if('alarm_co2' in capabilities){
-	  // CarbonDioxideDetected
-	  homekitAccessory
-	    .addService(Service.CarbonDioxideSensor, device.name)
-	    .getCharacteristic(Characteristic.CarbonDioxideDetected)
-	    .on('get', function(callback) {
-	      callback(null, ~~capValue('alarm_co2'));
-	    });
-	
-	  // CarbonDioxideLevel
-	  if('measure_co2' in capabilities){
-	  homekitAccessory
-	    .getService(Service.CarbonDioxideSensor)
-	    .getCharacteristic(Characteristic.CarbonDioxideLevel)
-	    .on('get', function(callback) {
-	      callback(null, capValue('measure_co2'));
-	    });
-	  }
+    // CarbonDioxideDetected
+    homekitAccessory
+      .addService(Service.CarbonDioxideSensor, device.name)
+      .getCharacteristic(Characteristic.CarbonDioxideDetected)
+      .on('get', function(callback) {
+        callback(null, ~~capValue('alarm_co2'));
+      });
+
+    // CarbonDioxideLevel
+    if('measure_co2' in capabilities){
+    homekitAccessory
+      .getService(Service.CarbonDioxideSensor)
+      .getCharacteristic(Characteristic.CarbonDioxideLevel)
+      .on('get', function(callback) {
+        callback(null, capValue('measure_co2'));
+      });
+    }
   }
 
   // On realtime event update the device
@@ -177,7 +177,7 @@ module.exports = function(device, api, capabilities) {
       .getCharacteristic(Characteristic.CurrentTemperature)
       .updateValue(capValue('measure_temperature'));
     }
-    
+
     // Humidity Sensor
     if('measure_humidity' in capabilities){
       homekitAccessory
@@ -225,7 +225,7 @@ module.exports = function(device, api, capabilities) {
         .getCharacteristic(Characteristic.SmokeDetected)
         .updateValue(~~capValue('alarm_smoke'));
     }
-    
+
     // Carbonmonoxide Sensor
     if('alarm_co' in capabilities){
       homekitAccessory

--- a/lib/devices/stateblinds.js
+++ b/lib/devices/stateblinds.js
@@ -4,50 +4,32 @@ const Characteristic = require('hap-nodejs').Characteristic;
 const uuid = require('hap-nodejs').uuid;
 const debounce = require('lodash.debounce');
 
-function state2value(state)
-{
-  if (state == 'down')
-  {
+function state2value(state) {
+  if (state == 'down') {
     return 0;
-  }
-  else if (state == 'up')
-  {
+  } else if (state == 'up') {
     return 100;
-  }
-  else
-  {
+  } else {
     return 50;
   }
 }
 
-function value2state(value)
-{
-  if (value == 100)
-  {
+function value2state(value) {
+  if (value == 100) {
     return 'up';
-  }
-  else if (value == 0)
-  {
+  } else if (value == 0) {
     return 'down';
-  }
-  else
-  {
+  } else {
     return 'idle';
   }
 }
 
-function state2num(state)
-{
-  if (state == 'up')
-  {
+function state2num(state) {
+  if (state == 'up') {
     return 1;
-  }
-  else if (state == 'down')
-  {
+  } else if (state == 'down') {
     return 0;
-  }
-  else
-  {
+  } else {
     return 2;
   }
 }

--- a/lib/devices/thermostat.js
+++ b/lib/devices/thermostat.js
@@ -4,21 +4,14 @@ const Characteristic = require('hap-nodejs').Characteristic;
 const uuid = require('hap-nodejs').uuid;
 const debounce = require('lodash.debounce');
 
-function state2value(state)
-{
-  if (state == 'off')
-  {
+function state2value(state) {
+  if (state == 'off') {
     return 0;
-  }
-  else if (state == 'heat')
-  {
+  } else if (state == 'heat') {
     return 1;
-  }
-  else if (state == 'cool')
-  {
+  } else if (state == 'cool') {
     return 2;
-  }
-  else {
+  } else {
     return 3;
   }
 }
@@ -75,12 +68,12 @@ module.exports = function(device, api) {
 
   // Humidity Sensor
   if ('measure_humidity' in device.capabilities) {
-	  homekitAccessory
-	    .getService(Service.Thermostat)
-	    .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-	    .on('get', function(callback) {
-	      callback(null, device.state.measure_humidity);
-	    });
+    homekitAccessory
+      .getService(Service.Thermostat)
+      .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+      .on('get', function(callback) {
+        callback(null, device.state.measure_humidity);
+      });
   }
 
   if ('thermostat_mode' in device.capabilities) {
@@ -122,8 +115,6 @@ module.exports = function(device, api) {
         callback(err, state2value(device.state.thermostat_mode));
       });
   }
-
-
 
   // On realtime event update the device
   device.on('$state', debounce(state => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "com.swttt.homekit",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,13 +21,14 @@
     },
     "bonjour": {
       "version": "github:abedinpour/bonjour#2845ce7606ecb58ce361726ade9ce71bcd9909c5",
+      "from": "bonjour@github:abedinpour/bonjour#2845ce7606ecb58ce361726ade9ce71bcd9909c5",
       "requires": {
-        "array-flatten": "2.1.1",
-        "deep-equal": "1.0.1",
-        "dns-equal": "1.0.0",
-        "dns-txt": "2.0.2",
-        "multicast-dns": "6.2.3",
-        "multicast-dns-service-types": "1.1.0"
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
       }
     },
     "buffer-indexof": {
@@ -45,8 +46,8 @@
       "resolved": "https://registry.npmjs.org/curve25519-n2/-/curve25519-n2-1.1.3.tgz",
       "integrity": "sha1-TLBYjs+327wL+zLQoARjKW7m7+I=",
       "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.8.0"
+        "bindings": "~1.2.1",
+        "nan": "^2.0.9"
       }
     },
     "debug": {
@@ -77,8 +78,8 @@
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.1"
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "dns-txt": {
@@ -86,7 +87,7 @@
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "requires": {
-        "buffer-indexof": "1.1.1"
+        "buffer-indexof": "^1.0.0"
       }
     },
     "ed25519": {
@@ -94,8 +95,8 @@
       "resolved": "https://registry.npmjs.org/ed25519/-/ed25519-0.0.4.tgz",
       "integrity": "sha1-5WIYrOL8kD0llZOu8LKpY59HW+s=",
       "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.8.0"
+        "bindings": "^1.2.1",
+        "nan": "^2.0.9"
       }
     },
     "fast-srp-hap": {
@@ -108,15 +109,15 @@
       "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.4.41.tgz",
       "integrity": "sha512-Yw7tkLEQYxXjM+g3MW4TVZRuGlqUiKRHod82Zqa+pYCVD2NNzzOFk37lk8op/qohj52iEoss8seS6rksa8pdcg==",
       "requires": {
-        "buffer-shims": "1.0.0",
-        "curve25519-n2": "1.1.3",
-        "debug": "2.6.9",
-        "decimal.js": "7.5.1",
-        "ed25519": "0.0.4",
-        "fast-srp-hap": "1.0.1",
-        "ip": "1.1.5",
-        "mdns": "2.3.4",
-        "node-persist": "0.0.11"
+        "buffer-shims": "^1.0.0",
+        "curve25519-n2": "^1.1.2",
+        "debug": "^2.2.0",
+        "decimal.js": "^7.2.3",
+        "ed25519": "^0.0.4",
+        "fast-srp-hap": "^1.0.1",
+        "ip": "^1.1.3",
+        "mdns": "^2.3.3",
+        "node-persist": "^0.0.11"
       }
     },
     "ip": {
@@ -134,8 +135,8 @@
       "resolved": "https://registry.npmjs.org/mdns/-/mdns-2.3.4.tgz",
       "integrity": "sha512-Z4WTKeTukCtJG53SS3BGNnsGkHdIXNZa9nwGMYeoohU1AjEBPS3c/1vIx95SEfeQKYduuOMTo1E4RfXDUt2ZYg==",
       "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.3.5"
+        "bindings": "~1.2.1",
+        "nan": "~2.3.0"
       },
       "dependencies": {
         "nan": {
@@ -168,8 +169,8 @@
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "requires": {
-        "dns-packet": "1.3.1",
-        "thunky": "1.0.2"
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
       }
     },
     "multicast-dns-service-types": {
@@ -187,8 +188,8 @@
       "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.11.tgz",
       "integrity": "sha1-1m66Pr72IPB5Uw+nsTB2qQZmWHQ=",
       "requires": {
-        "mkdirp": "0.5.1",
-        "q": "1.1.2"
+        "mkdirp": "~0.5.1",
+        "q": "~1.1.1"
       }
     },
     "os": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.swttt.homekit",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Homekit app for Homey",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Support for air pressure sensors.

Since HomeKit doesn't have an air pressure characteristic, it had to be implemented using a custom characteristic. It's modeled on the "Eve Home" custom characteristic for air pressure, which a lot of alternative Home apps support (for instance the [Home](https://itunes.apple.com/nl/app/home-smart-home-automation/id995994352?mt=8) app, which I use; screenshot below).

![image](https://user-images.githubusercontent.com/1190916/43365150-7a893756-9328-11e8-9184-2d2b4fe6b98c.png)
