### PR TITLE
Also support dimmable lights with virtualClass light

### DIFF
--- a/app.js
+++ b/app.js
@@ -134,7 +134,7 @@ class HomekitApp extends Homey.App {
     }, {});
 
     let isPaired = false;
-    if (device.class === 'light' && 'onoff' in capabilities) {
+    if ([device.class, device.virtualClass].includes('light') && 'onoff' in capabilities) {
       this.log('Found light: ' + device.name)
       isPaired = true;
       bridge.addBridgedAccessory(homekit.createLight(device, api, capabilities));


### PR DESCRIPTION
I have a few KIKA dimmers, which apparently have deviceclass "socket". This result in Homekit seeing those as on/off sockets, instead of dimmable lights. These devices however have virtualClass "light". This PR ensures these devices are exposed as dimmable lights.