### PR TITLE
Show zones and fix search for zones

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -42,13 +42,14 @@
                     </figure>
                   </div>
                   <div class='media-content'>
-                    <div class='has-text-centered title    is-4'>{{ device.name }}</div>
-                    <div class='has-text-centered subtitle is-6' style='margin-top: 0.5rem'>
-                      <a v-if="canRemove(device)" @click="removeDevice(device)" class="button is-outlined is-small is-danger"  data-i18n="device.delete">Delete</a>
-                      <a v-else                   @click="addDevice(device)"    class="button is-outlined is-small is-success" data-i18n="device.add">Add</a>
-                    </div>
+                    <div class='title    is-4'>{{ device.name }}</div>
+                    <div class='subtitle is-6'>{{ device.zoneName }}</div>
                   </div>
                 </div>
+              </div>
+              <div class='card-footer'>
+                <a v-if="canRemove(device)" @click="removeDevice(device)" class="card-footer-item is-danger"  data-i18n="device.delete">Delete</a>
+                <a v-else                   @click="addDevice(device)"    class="card-footer-item is-success" data-i18n="device.add">Add</a>
               </div>
             </div>
           </div>
@@ -304,7 +305,7 @@
         computed: {
           filteredItems() {
             var options = {
-              keys:               [ 'name', 'zone.name', 'class' ],
+              keys:               [ 'name', 'zoneName', 'class' ],
               shouldSort:         true,
               findAllMatches:     true,
               threshold:          0.6,

--- a/settings/mock-setup.js
+++ b/settings/mock-setup.js
@@ -14,10 +14,10 @@ void function() {
       path:   '/devices',
       fn:     function(args, cb) {
         cb(null, {
-          1 : { name: 'Lamp Woonkamer',  id : 1, class : 'light',  iconObj : { url : ICON }, capabilities : [ 'onoff', 'dim' ] },
-          2 : { name: 'Lamp Overloop',   id : 2, class : 'light',  iconObj : { url : ICON }, capabilities : [ 'onoff', 'dim' ] },
-          3 : { name: 'Schakelaar Kast', id : 3, class : 'socket', iconObj : { url : ICON }, capabilities : [ 'onoff' ] },
-          4 : { name: 'Bewegingsmelder', id : 4, class : 'sensor', iconObj : { url : ICON }, capabilities : [ 'alarm_motion' ] },
+          1 : { name: 'Lamp Woonkamer',  id : 1, class : 'light',  iconObj : { url : ICON }, capabilities : [ 'onoff', 'dim' ], zoneName: 'Woonkamer'  },
+          2 : { name: 'Lamp Overloop',   id : 2, class : 'light',  iconObj : { url : ICON }, capabilities : [ 'onoff', 'dim' ], zoneName: 'Overloop'   },
+          3 : { name: 'Schakelaar Kast', id : 3, class : 'socket', iconObj : { url : ICON }, capabilities : [ 'onoff' ],        zoneName: 'Woonkamer'  },
+          4 : { name: 'Bewegingsmelder', id : 4, class : 'sensor', iconObj : { url : ICON }, capabilities : [ 'alarm_motion' ], zoneName: 'Slaapkamer' },
         });
       }
     },


### PR DESCRIPTION
- Shows the zone of a device on the settings page
- Fixes search by zone on the settings page

Reason for PR:
If you use the same device name (eg "light") in multiple zones, you currently can not identity in the settings which device you are adding/deleting to homekit.

Sure you could put the zone in the name, but I can't be the only one who likes to keep his names short and simple. :-)